### PR TITLE
Fixed issue that caused the search result links to be broken

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ CHANGES for Crate ReadTheDocs Theme
 Unreleased
 ----------
 
+- Fixed issue that caused the search result links to be broken.
+
 2017/02/20 0.5.17
 -----------------
 

--- a/src/crate/theme/rtd/crate/static/js/searchtools.js
+++ b/src/crate/theme/rtd/crate/static/js/searchtools.js
@@ -410,10 +410,12 @@ var Search = {
       // results left, load the summary and display it
       if (results.length) {
         var item = results.pop();
+        var file_name = item[0];
+        var item_path = file_name.substr(0, file_name.lastIndexOf('.')) || file_name;
         var listItem = $('<li style="display:none"></li>');
         if (DOCUMENTATION_OPTIONS.FILE_SUFFIX === '') {
           // dirhtml builder
-          var dirname = item[0] + '/';
+          var dirname = item_path + '/';
           if (dirname.match(/\/index\/$/)) {
             dirname = dirname.substring(0, dirname.length-6);
           } else if (dirname == 'index/') {
@@ -425,8 +427,7 @@ var Search = {
         } else {
           // normal html builders
           listItem.append($('<a/>').attr('href',
-            item[0] + DOCUMENTATION_OPTIONS.FILE_SUFFIX +
-            highlightstring + item[2]).html(item[1]));
+            item_path + DOCUMENTATION_OPTIONS.FILE_SUFFIX + highlightstring + item[2]).html(item[1]));
         }
         if (item[3]) {
           listItem.append($('<span> (' + item[3] + ')</span>'));
@@ -435,7 +436,7 @@ var Search = {
             displayNextItem();
           });
         } else if (DOCUMENTATION_OPTIONS.HAS_SOURCE) {
-          $.ajax({url: DOCUMENTATION_OPTIONS.URL_ROOT + '_sources/' + item[0] + '.txt',
+          $.ajax({url: DOCUMENTATION_OPTIONS.URL_ROOT + '_sources/' + item_path + '.txt',
                   dataType: "text",
                   complete: function(jqxhr, textstatus) {
                     var data = jqxhr.responseText;


### PR DESCRIPTION
I couldn't figure out why the searchindex filenames have .txt extention in rtd (i couldn't reproduce in in crate master)

searchtools.js shouldn't make the assumption that filenames have no suffix and should work for both cases.