### PR TITLE
add CrateDB Guide and reshuffle docs organisation

### DIFF
--- a/src/crate/theme/rtd/conf/crate_guide.py
+++ b/src/crate/theme/rtd/conf/crate_guide.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; -*-
+#
+# Licensed to Crate (https://crate.io) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  Crate licenses
+# this file to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# However, if you have executed another commercial license agreement
+# with Crate these terms will supersede the license and you may use the
+# software solely pursuant to the terms of the relevant commercial agreement.
+
+from crate.theme.rtd.conf import *
+
+project = u'Crate Guide'
+
+html_theme_options.update({
+    'canonical_url_path': 'docs/projects/guide/',
+    'tracking_project': 'guide',
+})

--- a/src/crate/theme/rtd/crate/sidebartoc.html
+++ b/src/crate/theme/rtd/crate/sidebartoc.html
@@ -1,27 +1,32 @@
 <ul class="toctree nav nav-list">
-  <li class="navleft-item"><a href="/docs/install/">Install</a></li>
-  <li class="navleft-item"><a href="/docs/connect/">Connect to Cluster</a></li>
-  <li class="navleft-item"><a href="/docs/import/">Import Data</a></li>
-  <li class="navleft-item"><a href="/docs/clients/">Client Libraries</a></li>
-  <li class="navleft-item"><a href="/docs/scale/">Scale a Cluster</a></li>
-  <li class="navleft-item border-top"><a href="https://github.com/crate/crate-sample-apps">Sample Applications</a></li>
-  <li class="navleft-item"><a href="/docs/reference/overview">Reference</a></li>
+  <li class="navleft-item">CrateDB</li>
   <ul>
     {% if project == 'CrateDB' %}
     <li class="current">
-      <a class="current-active" href="{{ pathto(master_doc) }}" title="{{ project|e|striptags }}">Crate</a>
+      <a class="current-active" href="{{ pathto(master_doc) }}" title="{{ project|e|striptags }}">Reference</a>
       {{ toctree(maxdepth=3|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
     </li>
     {% else %}
-    <li class="navleft-item"><a href="/docs/reference/">Crate</a></li>
+    <li class="navleft-item"><a href="/docs/crate/reference">Reference</a></li>
     {% endif %}
-    {% if project == 'Crate Shell' %}
+    {% if project == 'Crate Guide' %}
     <li class="current">
-      <a class="current-active" href="{{ pathto(master_doc) }}" title="{{ project|e|striptags }}">Crate Shell</a>
+      <a class="current-active" href="{{ pathto(master_doc) }}" title="{{ project|e|striptags }}">Guide</a>
       {{ toctree(maxdepth=1|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
     </li>
     {% else %}
-    <li class="navleft-item"><a href="/docs/reference/crash">Crate Shell</a></li>
+    <li class="navleft-item"><a href="/docs/crate/guide">Guide</a></li>
+    {% endif %}
+  </ul>
+  <li class="navleft-item">CrateDB Clients</li>
+  <ul>
+    {% if project == 'Crate Shell' %}
+    <li class="current">
+      <a class="current-active" href="{{ pathto(master_doc) }}" title="{{ project|e|striptags }}">The CrateDB Shell</a>
+      {{ toctree(maxdepth=1|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
+    </li>
+    {% else %}
+    <li class="navleft-item"><a href="/docs/clients/crash">The CrateDB Shell</a></li>
     {% endif %}
     {% if project == 'Crate Python' %}
     <li class="current">
@@ -29,7 +34,7 @@
       {{ toctree(maxdepth=1|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
     </li>
     {% else %}
-    <li class="navleft-item"><a href="/docs/reference/python">Python</a></li>
+    <li class="navleft-item"><a href="/docs/clients/python">Python</a></li>
     {% endif %}
     {% if project == 'Crate Java Client' %}
     <li class="current">
@@ -37,7 +42,7 @@
       {{ toctree(maxdepth=1|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
     </li>
     {% else %}
-    <li class="navleft-item"><a href="/docs/reference/java">Java</a></li>
+    <li class="navleft-item"><a href="/docs/clients/java">Java</a></li>
     {% endif %}
     {% if project == 'Crate JDBC Driver' %}
     <li class="current">
@@ -45,7 +50,7 @@
       {{ toctree(maxdepth=1|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
     </li>
     {% else %}
-    <li class="navleft-item"><a href="/docs/reference/jdbc">JDBC</a></li>
+    <li class="navleft-item"><a href="/docs/clients/jdbc">JDBC</a></li>
     {% endif %}
     {% if project == 'Crate DBAL' %}
     <li class="current">
@@ -53,7 +58,7 @@
       {{ toctree(maxdepth=1|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
     </li>
     {% else %}
-    <li class="navleft-item"><a href="/docs/reference/dbal">PHP DBAL</a></li>
+    <li class="navleft-item"><a href="/docs/clients/dbal">PHP DBAL</a></li>
     {% endif %}
     {% if project == 'Crate PDO' %}
     <li class="current">
@@ -61,16 +66,18 @@
       {{ toctree(maxdepth=1|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
     </li>
     {% else %}
-    <li class="navleft-item"><a href="/docs/reference/pdo">PHP PDO</a></li>
+    <li class="navleft-item"><a href="/docs/clients/pdo">PHP PDO</a></li>
     {% endif %}
     {% if project == 'Crate Mesos Framework' %}
     <li class="current">
-      <a class="current-active" href="{{ pathto(master_doc) }}" title="{{ project|e|striptags }}">Crate Mesos Framework</a>
+      <a class="current-active" href="{{ pathto(master_doc) }}" title="{{ project|e|striptags }}">Mesos Framework</a>
       {{ toctree(maxdepth=1|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
     </li>
     {% else %}
-    <li class="navleft-item"><a href="/docs/reference/mesos-framework">Crate Mesos Framework</a></li>
+    <li class="navleft-item"><a href="/docs/clients/mesos-framework">Mesos Framework</a></li>
     {% endif %}
   </ul>
+
+  <li class="navleft-item border-top"><a href="https://github.com/crate/crate-sample-apps">Sample Applications</a></li>
   <li class="navleft-item"><a href="/docs/support/">Support</a></li>
 </ul>


### PR DESCRIPTION
this PR:

- retires the Cactus links
- adds links to the new CrateDB Guide
- reshuffles the organisation of the docs

see: https://trello.com/c/7od7BLjy/74

the menu now looks like this:

<img width="231" alt="screen shot 2017-06-16 at 19 43 48" src="https://user-images.githubusercontent.com/23469/27238162-29321ae6-52cc-11e7-9530-21ed881a0746.png">

the new URLs look like this:

/docs/cratedb/reference (the main CrateDB docs, a reference work)
/docs/cratedb/guide (the new CrateDB guide)

/docs/clients/crash
/docs/clients/python
/docs/clients/java
...

for this to work, we will have to update our fastly config