### PR TITLE
remove topic border

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,7 @@ CHANGES for Crate ReadTheDocs Theme
 Unreleased
 ----------
 
+- Remove topic div border
 
 2017/09/05 0.5.38
 -----------------

--- a/src/crate/theme/rtd/crate/static/css/crateio-rtd.css
+++ b/src/crate/theme/rtd/crate/static/css/crateio-rtd.css
@@ -186,3 +186,7 @@ a code {
     border: 0;
     font-weight: normal;
 }
+
+div.topic {
+    border: 0;
+}


### PR DESCRIPTION
I want to start using this:

```
.. contents::
   :local:
```

for local tocs. but the style atm adds a 1px border around them which looks bad. this makes local tocs look like regular tocs