### PR TITLE
Force canonical URL override on RTD

### DIFF
--- a/src/crate/theme/rtd/conf/__init__.py
+++ b/src/crate/theme/rtd/conf/__init__.py
@@ -52,9 +52,28 @@ html_theme_options = {
     # The URL path is required because RTD does only allow
     # root as a canonical url.
     'canonical_url_path': '',
-    'canonical_url': 'https://crate.io/docs/',
+    'canonical_url': 'https://crate.io/',
 
     # segment analytics configuration
     'tracking_segment_id': 'FToR4cE5lXyQziQirvt0kSnFQj0rAgu9',
     'tracking_project': '',
 }
+
+def setup(app):
+    """Force the canonical URL in multiple ways
+
+    This gets around several points where the canonical_url override might be
+    disregarded or performed out of order.
+
+    This module should be star imported into `create_*.py`, and thus star
+    imported into the base `conf.py`. Sphinx will automatically use a `setup()`
+    in `conf.py` as an extension.
+    """
+    def force_canonical_url(app_inited):
+        canonical_url = app_inited.builder.theme_options['canonical_url']
+        canonical_url_path = app_inited.builder.theme_options['canonical_url_path']
+        canonical_url = canonical_url + canonical_url_path
+        app_inited.env.config.html_context['canonical_url'] = canonical_url
+        app_inited.builder.config.html_context['canonical_url'] = canonical_url
+
+    app.connect('builder-inited', force_canonical_url)

--- a/src/crate/theme/rtd/crate/layout.html
+++ b/src/crate/theme/rtd/crate/layout.html
@@ -33,13 +33,6 @@
   <meta http-equiv='X-UA-Compatible' content='IE=edge,chrome=1'>
   <meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1'>
   <meta name="apple-mobile-web-app-capable" content="yes">
-  {% set ending = "/" if builder == "readthedocsdirhtml" else ".html" %}
-  {% set canonical_page = pagename + ending %}
-  <!-- {{ canonical_url }} -->
-  {% if canonical_url %}
-    <!-- CANONICAL URL AS SET BY CRATE THEME -->
-    <link rel="canonical" href="https://crate.io/{{ theme_canonical_url_path }}{{ canonical_page.replace("index.html", "").replace("index/", "") }}" />
-  {% endif %}
   {% endblock %}
 
   {# Silence the sidebar's, relbar's #}


### PR DESCRIPTION
Read the Docs forces its own canonical URL, so to override this, we must set up
the override at a later stage in the Sphinx initialization. Further, because we
use a custom extension ourselves, we have to compete with the order of Sphinx
extension initialization.

No changes should be required to child `conf.py` files, as all the configuration
already exists in the `crate_*.py` config files. Namely, the
`canonical_url_path` theme option should be altered to the correct path.