### PR TITLE
Conditionally apply canonical url patch based on builder type

### DIFF
--- a/src/crate/theme/rtd/conf/__init__.py
+++ b/src/crate/theme/rtd/conf/__init__.py
@@ -70,10 +70,12 @@ def setup(app):
     in `conf.py` as an extension.
     """
     def force_canonical_url(app_inited):
-        canonical_url = app_inited.builder.theme_options['canonical_url']
-        canonical_url_path = app_inited.builder.theme_options['canonical_url_path']
-        canonical_url = canonical_url + canonical_url_path
-        app_inited.env.config.html_context['canonical_url'] = canonical_url
-        app_inited.builder.config.html_context['canonical_url'] = canonical_url
+        from sphinx.builders.html import StandaloneHTMLBuilder
+        if isinstance(app_inited.builder, StandaloneHTMLBuilder):
+            canonical_url = app_inited.builder.theme_options['canonical_url']
+            canonical_url_path = app_inited.builder.theme_options['canonical_url_path']
+            canonical_url = canonical_url + canonical_url_path
+            app_inited.env.config.html_context['canonical_url'] = canonical_url
+            app_inited.builder.config.html_context['canonical_url'] = canonical_url
 
     app.connect('builder-inited', force_canonical_url)


### PR DESCRIPTION
This wasn't tested against LaTeX builder, and the context data doesn't exist on
this builder. This patch only patches the HTML builder subclasses.