### PR TITLE
Added dependency to 'sphinx_sitemap' so that we can build sitemaps

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ CHANGES for Crate ReadTheDocs Theme
 Unreleased
 ----------
 
+- Added dependency to sphinx_sitemap
+
+
 2018/02/01 0.5.51
 -----------------
 

--- a/setup.py
+++ b/setup.py
@@ -53,5 +53,6 @@ setup(name='crate-docs-theme',
           'setuptools',
           'Sphinx',
           'sphinxcontrib-plantuml',
+          'sphinx_sitemap',
       ],
 )


### PR DESCRIPTION
* We relaunched the Website Refresh yesterday
* We want to have a proper Sitemap setup
* We use https://github.com/jdillard/sphinx-sitemap to build the sitemaps automatically
* We need to get the dependency into the theme before we can change the documentation in the projects