### PR TITLE
add sql-99 project (hidden, for now)

### DIFF
--- a/src/crate/theme/rtd/conf/sql_99.py
+++ b/src/crate/theme/rtd/conf/sql_99.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; -*-
+#
+# Licensed to Crate (https://crate.io) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  Crate licenses
+# this file to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# However, if you have executed another commercial license agreement
+# with Crate these terms will supersede the license and you may use the
+# software solely pursuant to the terms of the relevant commercial agreement.
+
+from crate.theme.rtd.conf import *
+
+project = u'SQL 99'
+
+html_theme_options.update({
+    'canonical_url_path': 'docs/sql-99/en/latest/',
+    'tracking_project': 'sql-99',
+})

--- a/src/crate/theme/rtd/crate/sidebartoc.html
+++ b/src/crate/theme/rtd/crate/sidebartoc.html
@@ -79,5 +79,13 @@
   </ul>
 
   <li class="navleft-item border-top"><a href="https://github.com/crate/crate-sample-apps">Sample Applications</a></li>
+
+  {% if project == 'SQL 99' %}
+  <li class="current">
+    <a class="current-active" href="{{ pathto(master_doc) }}" title="{{ project|e|striptags }}">SQL-99 Complete, Really</a>
+    {{ toctree(maxdepth=1|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
+  </li>
+  {% endif %}
+
   <li class="navleft-item"><a href="/docs/support/">Support</a></li>
 </ul>


### PR DESCRIPTION
this activates the SQL-99 project so that the docs theme can be used by the new docs project. however, the nav link only shows up if you navigate directly to the project. once this is ready for a proper launch, I will change this so it always shows up in the navbar