### PR TITLE
Nail docs requirements versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,9 +50,9 @@ setup(name='crate-docs-theme',
       include_package_data=True,
       zip_safe=False,
       install_requires=[
-          'setuptools',
-          'Sphinx',
-          'sphinxcontrib-plantuml',
-          'sphinx_sitemap',
+          'setuptools==40.6.3',
+          'Sphinx==1.7.4',
+          'sphinxcontrib-plantuml==0.14',
+          'sphinx_sitemap==0.3.1',
       ],
 )


### PR DESCRIPTION
This should fix the issue of our sitemaps being broken. Here is what (I'm pretty certain) happened:

A new version of sphinx-sitemaps was released last month, which included language support. This language support appended the language of the site to the base-url (see https://github.com/jdillard/sphinx-sitemap/blob/master/sphinx_sitemap/__init__.py#L79). Our base url for the, for example, crash docs are `https://crate.io/docs/clients/crash/en/latest/`. This appending of the language results in `https://crate.io/docs/clients/crash/en/latest/en/`, and our rewrites mangle it into `https://crate.io/docs/clients/crash/en/latest/en//....`.

Our docs projects were recently rebuilt, which made RTD pick up the latest version of sphinx-sitemaps which had this feature, since the versions were not nailed to specific ones.

This PR nails these versions. I imagine we'll have to do a release of the theme and update our docs to use this version. This should fix the sitemaps.