### PR TITLE
Docs Footer Update

### DIFF
--- a/src/crate/theme/rtd/crate/footer.html
+++ b/src/crate/theme/rtd/crate/footer.html
@@ -10,7 +10,6 @@
             <li class="footer-listitem-new"><a href="https://crate.io/products/crate-iot-data-platform/">Crate IoT Data Platform</a></li>
             <li class="footer-listitem-new"><a href="https://crate.io/products/cratedb-community-edition/">Community Edition</a></li>
             <li class="footer-listitem-new"><a href="https://crate.io/cratedb-comparison/">CrateDB Comparison</a></li>
-            <li class="footer-listitem-new"><a href="https://crate.io/event-hubs-integration/">Event Hubs Integration</a></li>
             <li class="footer-listitem-new"><a href="https://crate.io/pricing/">Pricing</a></li>
             <li class="footer-listitem-new"><a href="https://crate.io/download/">Get CrateDB</a></li>
           </ul>


### PR DESCRIPTION
Deleted the Eventhub Integration Page, which is deprecated.
