### PR TITLE
don't load jquery with sphinx script_files

### DIFF
--- a/src/crate/theme/rtd/crate/base.html
+++ b/src/crate/theme/rtd/crate/base.html
@@ -103,7 +103,9 @@
     <script type="text/javascript" src="{{ pathto(scriptfile, 1) }}?ver=1.1"></script>
     {%- endfor %}
     {%- for scriptfile in script_files %}
+      {%- if "jquery" not in scriptfile %}
     <script type="text/javascript" src="{{ pathto(scriptfile, 1) }}?ver=1.1"></script>
+      {%- endif %}
     {%- endfor %}
 {%- endmacro %}
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

sphinx loads jquery v3.2.1 which conflicts with the version required for the theme, which is 1.11.1.
this causes the cookie error

https://github.com/sphinx-doc/sphinx/blob/master/sphinx/builders/html.py#L304

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
