### PR TITLE
Adding a view on GitHub button

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,12 @@ CHANGES for Crate.io Documentation Theme
 Unreleased
 ----------
 
+- Added a "view on GitHub" button
+- Added a key Shortcut ctrl + e to open the GitHub page.
+
 2019/09/23 0.5.85
 -----------------
+
 - Display Cloud Getting Started link
 
 2019/08/16 0.5.84

--- a/src/crate/theme/rtd/crate/layout.html
+++ b/src/crate/theme/rtd/crate/layout.html
@@ -3,7 +3,7 @@
   {% set css_files = [
     '_static/css/normalize.css',
     '_static/css/bootstrap.css',
-    
+
     '_static/css/components.css',
     '_static/css/crateio.css',
     '_static/css/crateio-rtd.css',
@@ -18,12 +18,18 @@
     '_static/js/searchtools.js',
     '_static/js/webflow.js',
     '_static/js/bootstrap.js',
-    
+
     '_static/js/fontawesome.js',
     '_static/js/custom.js',
     '_static/js/sticky-sidebar.min.js'
     ]
   %}
+
+  {% if page_source_suffix %}
+  {% set suffix = page_source_suffix %}
+  {% else %}
+  {% set suffix = source_suffix %}
+  {% endif %}
 
   {%- block doctype -%}
   <!DOCTYPE html>
@@ -64,6 +70,16 @@
         </div>
         <div class="col-md-8 col-lg-9">
           <div class="wrapper-content-right">
+            {% if display_github %}
+              <div class="view-on-github">
+              {% if check_meta and 'github_url' in meta %}
+                <!-- User defined GitHub URL -->
+                <a href="{{ meta['github_url'] }}" class="fa fa-github"></a>
+              {% else %}
+                <a href="https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/{{ theme_vcs_pageview_mode|default("blob") }}/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ suffix }}" class="fa fa-github"></a>
+              {% endif %}
+              </div>
+            {% endif %}
             {%- if current_version %}
             <div class="version-select-container">
               <div data-delay="0" class="w-dropdown">
@@ -92,6 +108,20 @@
   {%- endblock %}
 
   {%- block custom_footer %}
+
+  {% if display_github %}
+  <script>
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'e' && event.ctrlKey) {
+        {% if check_meta and 'github_url' in meta %}
+          location.href = "{{ meta['github_url'] }}";
+        {% else %}
+          location.href = "https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/{{ theme_vcs_pageview_mode|default("blob") }}/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ suffix }}";
+        {% endif %}
+      }
+    });
+  </script>
+  {% endif %}
 
   <script>
 

--- a/src/crate/theme/rtd/crate/static/css/crateio.css
+++ b/src/crate/theme/rtd/crate/static/css/crateio.css
@@ -1320,6 +1320,16 @@ a.learn-more-link, .wrapper-teaser-img p {
   float: right;
   text-align: right;
 }
+.view-on-github{
+  display: block;
+  float: right;
+  padding: 8px 15px;
+  border: 1px solid #e7e7e7;
+  border-left: none;
+}
+.view-on-github .fa-github:before{
+  font-size: 24px;
+}
 
 .toggle {
   padding-top: 10px;


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Added a view on GitHub button so people reading the Documentation don't have to search for the right repo if they have a problem or want to ask or suggest something. 

## Checklist

 - [x] User is able to get directed to the right GitHub repo without having to search for it
 - [x] A key shortcut is added, so if the user is in the know, he can hit `CTRL+e` and bring up a GitHub window