### PR TITLE
Msbt

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ CHANGES for Crate.io Documentation Theme
 Unreleased
 ----------
 
+- Removed a function that hides the toggled docs menu on mobile.
+
 2020/01/20 0.7.3
 ----------------
 

--- a/src/crate/theme/rtd/crate/layout.html
+++ b/src/crate/theme/rtd/crate/layout.html
@@ -138,7 +138,6 @@
 
   } else {
 
-    $('.wrapper-navleft').hide();
     $('#mobile-menu-toggler').click(function() {
       $('.wrapper-navleft').toggle();
     });


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

removed a jquery function that hides the mobile docs-nav when the toggler is no longer visible, this is not wanted behaviour

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
