### PR TITLE
Msbt

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@ CHANGES for Crate.io Documentation Theme
 Unreleased
 ----------
 
+- Edited a function that shows/hides the toggled docs menu on mobile.
+- Changed ``z-index`` of ``header.header-nav`` so ``version-select-container``
+  won't overlap on mobile
+
 2020/01/21 0.7.4
 ----------------
 

--- a/src/crate/theme/rtd/crate/layout.html
+++ b/src/crate/theme/rtd/crate/layout.html
@@ -139,7 +139,8 @@
   } else {
 
     $('#mobile-menu-toggler').click(function() {
-      $('.wrapper-navleft').toggle();
+      $('#mobile-menu-toggler').toggleClass('w-active');
+      $('.wrapper-navleft').toggleClass('shownav');
     });
 
   }

--- a/src/crate/theme/rtd/crate/static/css/custom.css
+++ b/src/crate/theme/rtd/crate/static/css/custom.css
@@ -321,7 +321,7 @@ body .mm-menu .navbar-nav {
     left: 0;
     width: 100%;
     border-bottom: 1px solid rgba(0, 0, 0, .1) !important;
-    z-index: 10;
+    z-index: 990;
   }
 
   div.section {
@@ -747,4 +747,17 @@ header.header-nav {
 
 .is-affixed .sidebar__inner {
   left: initial !important;
+}
+
+.wrapper-navleft.shownav {
+  display: block !important;
+}
+
+#mobile-menu-toggler.w-button:focus {
+  color: white;
+}
+
+#mobile-menu-toggler.w-button.w-active {
+  color: #0ec1ef;
+  opacity: 0.7;
 }


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Mobile nav still disappears when scrolling on mobile, the added classes should fix it

Currently on mobile (<768px) the version-picker overlaps the sticky menu when scrolling down, a higher z-index fixes this issue

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
