### PR TITLE
Updated Feedback section & tracking

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ CHANGES for Crate.io Documentation Theme
 Unreleased
 ----------
 
+- Improved Feedback section (one fetch instead of two) and updated tracking
 
 2020/05/18 0.9.5
 ----------------

--- a/src/crate/theme/rtd/crate/layout.html
+++ b/src/crate/theme/rtd/crate/layout.html
@@ -184,8 +184,7 @@
     !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on","setAnonymousId"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t){var e=document.createElement("script");e.type="text/javascript";e.async=!0;e.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};analytics.SNIPPET_VERSION="4.0.0";
       analytics.load("{{ theme_tracking_segment_id }}");
       analytics.setAnonymousId($.cookie('uid'));
-      analytics.page();
-      analytics.track('visited_section_docs', {
+      analytics.page('visited_section_docs', {
         project: '{{ theme_tracking_project }}',
         version: '{{ current_version }}'
       });
@@ -292,32 +291,35 @@
 
             const content = document.getElementById('cr-feedback-content');
             content.innerHTML = '<p>Loading data...</p>';
-            Promise.all([
-              fetchIssues("https://api.{{ github_host|default('github.com') }}/search/issues?q=repo:{{ github_user }}/{{ github_repo }}+label:documentation+is:open+{{ pagename|urlencode }}.html"),
-              fetchIssues("https://api.{{ github_host|default('github.com') }}/search/issues?q=repo:{{ github_user }}/{{ github_repo }}+label:documentation+is:closed+{{ pagename|urlencode }}.html")
-              ]).then(function ([openIssues, closedIssues]) {
-                var html = makeIssueHeader(openIssues['items'], closedIssues['items']);
-                html += listIssues(openIssues['items']);
-                html += listIssues(closedIssues['items'], true);
-                content.innerHTML = html;
-                const openButton = document.getElementById('issues-open');
-                const closedButton = document.getElementById('issues-closed');
-                const openList = document.getElementById('cr-docs-issues-open-list');
-                const closedList = document.getElementById('cr-docs-issues-closed-list');
-                openButton.addEventListener('click', function (e) {
-                  openButton.classList.add('cr-fb-active');
-                  closedButton.classList.remove('cr-fb-active');
-                  openList.style.display = 'block';
-                  closedList.style.display = 'none';
-                });
-                closedButton.addEventListener('click', function (e) {
-                  openButton.classList.remove('cr-fb-active');
-                  closedButton.classList.add('cr-fb-active');
-                  openList.style.display = 'none';
-                  closedList.style.display = 'block';
-                });
-              }).catch(function() {
-            // if rate limit exceeded, throw this error
+            fetchIssues("https://api.{{ github_host|default('github.com') }}/search/issues?q=repo:{{ github_user }}/{{ github_repo }}+label:documentation+{{ pagename|urlencode }}.html")
+                .then(function (issues) {
+                  const openIssues = issues.items.filter(x => x.state == 'open');
+                  const closedIssues = issues.items.filter(x => x.state == 'closed');
+                  var html = makeIssueHeader(openIssues, closedIssues);
+                  html += listIssues(openIssues);
+                  html += listIssues(closedIssues, true);
+                  content.innerHTML = html;
+                  const openButton = document.getElementById('issues-open');
+                  const closedButton = document.getElementById('issues-closed');
+                  const openList = document.getElementById('cr-docs-issues-open-list');
+                  const closedList = document.getElementById('cr-docs-issues-closed-list');
+                  openButton.addEventListener('click', function (e) {
+                    openButton.classList.add('cr-fb-active');
+                    closedButton.classList.remove('cr-fb-active');
+                    openList.style.display = 'block';
+                    closedList.style.display = 'none';
+                  });
+                  closedButton.addEventListener('click', function (e) {
+                    openButton.classList.remove('cr-fb-active');
+                    closedButton.classList.add('cr-fb-active');
+                    openList.style.display = 'none';
+                    closedList.style.display = 'block';
+                  });
+
+                analytics.track('Feedback Opened');
+
+                }).catch(function() {
+                // if rate limit exceeded, throw this error
                 content.innerHTML = '<p>Error loading data, limit exceeded. Please try again later.</p>';
                 analytics.track('DOCS RATE LIMIT', {
                   location: 'Center',


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

1. Only one call instead of two to the GitHub search API, which will help with the rate limit.
2. Removed an analytics.track() call, those aren't supposed to be triggered on every pageview, that's what analytics.page() is for. Added a track call for when the Feedback section is loaded (i.e. when someone scrolls at the end of a doc).

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
