### PR TITLE
open external links with target blank by default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ CHANGES for Crate.io Documentation Theme
 Unreleased
 ----------
 
+- Added a snippet in ``custom.js`` to open all external links in a new window 
+  by default
 
 2020/05/18 0.9.5
 ----------------

--- a/src/crate/theme/rtd/crate/static/js/custom.js
+++ b/src/crate/theme/rtd/crate/static/js/custom.js
@@ -64,7 +64,10 @@
     var viewportHeight = Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
     var $sidebar = $('.bs-docs-sidebar');
     $sidebar.css('max-height', `${viewportHeight - 40}px`);
-  });
 
+    // open all external links in new window
+    jQuery(document.links) .filter(function() { 
+    return this.hostname != window.location.hostname; }) .attr('target', '_blank');
+  });
 
 })(jQuery);


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Open external links with `target=_blank` by default

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
