### PR TITLE
Fix links in the docs issue template

### DIFF
--- a/src/crate/theme/rtd/crate/layout.html
+++ b/src/crate/theme/rtd/crate/layout.html
@@ -110,9 +110,9 @@
                             }}{{
                               '- Page title: '|urlencode }}{{ title|striptags|urlencode }}{{ '%0A'
                             }}{{
-                              '- Page URL: https://crate.io/'|urlencode }}{{ theme_canonical_url_path|urlencode }}{{ pagename|urlencode }}{{ suffix }}{{ '%0A'
+                              '- Page URL: https://crate.io/'|urlencode }}{{ theme_canonical_url_path|urlencode }}{{ pagename|urlencode }}.html{{ '%0A'
                             }}{{
-                              '- Source: https://'|urlencode }}{{ github_host|default('github.com') }}/{{ github_user }}/{{ github_repo }}/{{ theme_vcs_pageview_mode|default('blob') }}/{{ github_version }}{{ conf_py_path|urlencode }}{{ pagename|urlencode }}.html{{ '%0A'
+                              '- Source: https://'|urlencode }}{{ github_host|default('github.com') }}/{{ github_user }}/{{ github_repo }}/{{ theme_vcs_pageview_mode|default('blob') }}/{{ github_version }}{{ conf_py_path|urlencode }}{{ pagename|urlencode }}{{ suffix }}{{ '%0A'
                             }}{{ '%0A'
                             }}---{{ '%0A'
                             }}{{ '%0A'


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

The generated links for when someone opens a docs issue needs to have their suffix swapped.

The swap needs to happen for "Page URL" and "Source".  The source links should always end with HTML. 

Note: I wanted to add a note in CHANGES.rst after pulling https://github.com/crate/crate-docs-theme/pull/187
