### PR TITLE
Remove tracking segments code from docs theme

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,13 @@
 CHANGES for Crate.io Documentation Theme
 ========================================
 
+Unreleased
+----------
+
+- Removed hardcoded segment tracking id. Instead, this is now settable in the
+  project's conf.py, or by exporting the ``TRACKING_SEGMENT_ID`` environment
+  variable during the build.
+
 2020/06/04 0.9.6
 ----------------
 

--- a/src/crate/theme/rtd/conf/__init__.py
+++ b/src/crate/theme/rtd/conf/__init__.py
@@ -19,8 +19,8 @@
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
 
-import hashlib
 from crate.theme import rtd as theme
+from os import environ
 
 source_suffix = '.rst'
 
@@ -54,7 +54,7 @@ html_theme_options = {
     'canonical_url': 'https://crate.io/',
 
     # segment analytics configuration
-    'tracking_segment_id': 'FToR4cE5lXyQziQirvt0kSnFQj0rAgu9',
+    'tracking_segment_id': environ.get('TRACKING_SEGMENT_ID', ''),
     'tracking_project': '',
 }
 

--- a/src/crate/theme/rtd/crate/layout.html
+++ b/src/crate/theme/rtd/crate/layout.html
@@ -179,6 +179,7 @@
     }
   </script>
 
+  {% if theme_tracking_segment_id %}
   <!-- Segment -->
   <script>
     !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on","setAnonymousId"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t){var e=document.createElement("script");e.type="text/javascript";e.async=!0;e.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};analytics.SNIPPET_VERSION="4.0.0";
@@ -190,6 +191,7 @@
       });
     }}();
   </script>
+  {% endif %}
 
   <!-- GitHub feedback section -->
   <script>
@@ -316,18 +318,21 @@
                     closedList.style.display = 'block';
                   });
 
+                {% if theme_tracking_segment_id %}
                 analytics.track('Feedback Opened');
-
+                {% endif %}
                 }).catch(function() {
                 // if rate limit exceeded, throw this error
                 content.innerHTML = '<p>Error loading data, limit exceeded. Please try again later.</p>';
+                {% if theme_tracking_segment_id %}
                 analytics.track('DOCS RATE LIMIT', {
                   location: 'Center',
                   text: 'Error loading data, limit exceeded. Please try again later.',
                   category: 'Docs',
                   type: 'Text',
                   pageTitle: document.title
-            });
+               });
+               {% endif %}
         });
     }
   </script>


### PR DESCRIPTION
This should be set up by individual projects, rather than being
hardcoded into the theme itself. Alongside this, if the analytics id
code is not set, the analytics library is not loaded.
