### PR TITLE
Downgraded Sphinx dependency to 1.8.5 (matches new RTD default)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ CHANGES for Crate.io Documentation Theme
 Unreleased
 ----------
 
+- Downgraded Sphinx dependency to 1.8.5 (matches new RTD default)
+
+
 2020/07/20 0.10.1
 -----------------
 

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name='crate-docs-theme',
       include_package_data=True,
       zip_safe=False,
       install_requires=[
-          'Sphinx==3.1.2',
+          'Sphinx==1.8.5',
           'sphinxcontrib-plantuml==0.14',
           'sphinx_sitemap==0.3.1',
       ],


### PR DESCRIPTION
for https://github.com/crate/tech-writing-domain/issues/135