### PR TITLE
Remove html_extra_path from crate-howtos.py

### DIFF
--- a/src/crate/theme/rtd/conf/crate_howtos.py
+++ b/src/crate/theme/rtd/conf/crate_howtos.py
@@ -33,4 +33,3 @@ html_theme_options.update({
     'canonical_url_path': url_path, # For rel="canonical" links
 })
 
-html_extra_path = ['robots.txt']


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

this was left in from previous testing and is breaking the build
