### PR TITLE
Configure sitemap_url_scheme for Read The Docs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,13 @@
 CHANGES for Crate.io Documentation Theme
 ========================================
 
+UNRELEASED
+----------
+
+- The sitemap_url_scheme setting is now manually configured so that sitemap
+  links work correctly when built locally and on Read The Docs.
+
+
 2020/08/27 0.10.12
 ------------------
 

--- a/src/crate/theme/rtd/conf/__init__.py
+++ b/src/crate/theme/rtd/conf/__init__.py
@@ -59,6 +59,10 @@ html_theme_options = {
 }
 html_extra_path = ["_extra"]
 sitemap_filename = "site.xml"
+# These variables are overridden by Read The Docs
+language = "en"
+version = "latest"
+sitemap_url_scheme = "{lang}{version}{link}"
 
 def setup(app):
     # Force the canonical URL in multiple ways

--- a/src/crate/theme/rtd/conf/cloud_cli.py
+++ b/src/crate/theme/rtd/conf/cloud_cli.py
@@ -24,11 +24,12 @@ from crate.theme.rtd.conf import *
 project = u'CrateDB Cloud: Croud CLI'
 html_title = project
 
-url_path = 'docs/cloud/cli/en/latest/'
+url_path = 'docs/cloud/cli'
 
 # For sitemap extension
-html_baseurl = 'https://crate.io/%s' % url_path
+html_baseurl = 'https://crate.io/%s/' % url_path
 
+# For rel="canonical" links
 html_theme_options.update({
-    'canonical_url_path': url_path, # For rel="canonical" links
+    'canonical_url_path': '%s/en/latest/' % url_path,
 })

--- a/src/crate/theme/rtd/conf/cloud_howtos.py
+++ b/src/crate/theme/rtd/conf/cloud_howtos.py
@@ -24,11 +24,12 @@ from crate.theme.rtd.conf import *
 project = u'CrateDB Cloud: How-To Guides'
 html_title = project
 
-url_path = 'docs/cloud/howtos/en/latest/'
+url_path = 'docs/cloud/howtos'
 
 # For sitemap extension
-html_baseurl = 'https://crate.io/%s' % url_path
+html_baseurl = 'https://crate.io/%s/' % url_path
 
+# For rel="canonical" links
 html_theme_options.update({
-    'canonical_url_path': url_path, # For rel="canonical" links
+    'canonical_url_path': '%s/en/latest/' % url_path,
 })

--- a/src/crate/theme/rtd/conf/cloud_reference.py
+++ b/src/crate/theme/rtd/conf/cloud_reference.py
@@ -24,11 +24,12 @@ from crate.theme.rtd.conf import *
 project = u'CrateDB Cloud: Reference'
 html_title = project
 
-url_path = 'docs/cloud/reference/en/latest/'
+url_path = 'docs/cloud/reference'
 
 # For sitemap extension
-html_baseurl = 'https://crate.io/%s' % url_path
+html_baseurl = 'https://crate.io/%s/' % url_path
 
+# For rel="canonical" links
 html_theme_options.update({
-    'canonical_url_path': url_path, # For rel="canonical" links
+    'canonical_url_path': '%s/en/latest/' % url_path,
 })

--- a/src/crate/theme/rtd/conf/cloud_tutorials.py
+++ b/src/crate/theme/rtd/conf/cloud_tutorials.py
@@ -24,11 +24,12 @@ from crate.theme.rtd.conf import *
 project = u'CrateDB Cloud: Tutorials'
 html_title = project
 
-url_path = 'docs/cloud/tutorials/en/latest/'
+url_path = 'docs/cloud/tutorials'
 
 # For sitemap extension
-html_baseurl = 'https://crate.io/%s' % url_path
+html_baseurl = 'https://crate.io/%s/' % url_path
 
+# For rel="canonical" links
 html_theme_options.update({
-    'canonical_url_path': url_path, # For rel="canonical" links
+    'canonical_url_path': '%s/en/latest/' % url_path,
 })

--- a/src/crate/theme/rtd/conf/crate_admin_ui.py
+++ b/src/crate/theme/rtd/conf/crate_admin_ui.py
@@ -24,11 +24,12 @@ from crate.theme.rtd.conf import *
 project = u'CrateDB: Admin UI'
 html_title = project
 
-url_path = 'docs/crate/admin-ui/en/latest/'
+url_path = 'docs/crate/admin-ui'
 
 # For sitemap extension
-html_baseurl = 'https://crate.io/%s' % url_path
+html_baseurl = 'https://crate.io/%s/' % url_path
 
+# For rel="canonical" links
 html_theme_options.update({
-    'canonical_url_path': url_path, # For rel="canonical" links
+    'canonical_url_path': '%s/en/latest/' % url_path,
 })

--- a/src/crate/theme/rtd/conf/crate_clients_tools.py
+++ b/src/crate/theme/rtd/conf/crate_clients_tools.py
@@ -24,11 +24,12 @@ from crate.theme.rtd.conf import *
 project = u'CrateDB: Clients and Tools'
 html_title = project
 
-url_path = 'docs/crate/client-tools/en/latest/'
+url_path = 'docs/crate/client-tools'
 
 # For sitemap extension
-html_baseurl = 'https://crate.io/%s' % url_path
+html_baseurl = 'https://crate.io/%s/' % url_path
 
+# For rel="canonical" links
 html_theme_options.update({
-    'canonical_url_path': url_path, # For rel="canonical" links
+    'canonical_url_path': '%s/en/latest/' % url_path,
 })

--- a/src/crate/theme/rtd/conf/crate_crash.py
+++ b/src/crate/theme/rtd/conf/crate_crash.py
@@ -24,11 +24,12 @@ from crate.theme.rtd.conf import *
 project = u'CrateDB: Crash CLI'
 html_title = project
 
-url_path = 'docs/crate/crash/en/latest/'
+url_path = 'docs/crate/crash'
 
 # For sitemap extension
-html_baseurl = 'https://crate.io/%s' % url_path
+html_baseurl = 'https://crate.io/%s/' % url_path
 
+# For rel="canonical" links
 html_theme_options.update({
-    'canonical_url_path': url_path, # For rel="canonical" links
+    'canonical_url_path': '%s/en/latest/' % url_path,
 })

--- a/src/crate/theme/rtd/conf/crate_howtos.py
+++ b/src/crate/theme/rtd/conf/crate_howtos.py
@@ -24,12 +24,12 @@ from crate.theme.rtd.conf import *
 project = u'CrateDB: How-To Guides'
 html_title = project
 
-url_path = 'docs/crate/howtos/en/latest/'
+url_path = 'docs/crate/howtos'
 
 # For sitemap extension
-html_baseurl = 'https://crate.io/%s' % url_path
+html_baseurl = 'https://crate.io/%s/' % url_path
 
+# For rel="canonical" links
 html_theme_options.update({
-    'canonical_url_path': url_path, # For rel="canonical" links
+    'canonical_url_path': '%s/en/latest/' % url_path,
 })
-

--- a/src/crate/theme/rtd/conf/crate_reference.py
+++ b/src/crate/theme/rtd/conf/crate_reference.py
@@ -24,11 +24,12 @@ from crate.theme.rtd.conf import *
 project = u'CrateDB: Reference'
 html_title = project
 
-url_path = 'docs/crate/reference/en/latest/'
+url_path = 'docs/crate/reference'
 
 # For sitemap extension
-html_baseurl = 'https://crate.io/%s' % url_path
+html_baseurl = 'https://crate.io/%s/' % url_path
 
+# For rel="canonical" links
 html_theme_options.update({
-    'canonical_url_path': url_path, # For rel="canonical" links
+    'canonical_url_path': '%s/en/latest/' % url_path,
 })

--- a/src/crate/theme/rtd/conf/crate_tutorials.py
+++ b/src/crate/theme/rtd/conf/crate_tutorials.py
@@ -24,12 +24,12 @@ from crate.theme.rtd.conf import *
 project = u'CrateDB: Tutorials'
 html_title = project
 
-url_path = 'docs/crate/tutorials/en/latest/'
+url_path = 'docs/crate/tutorials'
 
 # For sitemap extension
-html_baseurl = 'https://crate.io/%s' % url_path
+html_baseurl = 'https://crate.io/%s/' % url_path
 
+# For rel="canonical" links
 html_theme_options.update({
-    'canonical_url_path': url_path, # For rel="canonical" links
+    'canonical_url_path': '%s/en/latest/' % url_path,
 })
-

--- a/src/crate/theme/rtd/conf/dbal.py
+++ b/src/crate/theme/rtd/conf/dbal.py
@@ -24,11 +24,12 @@ from crate.theme.rtd.conf import *
 project = u'CrateDB DBAL'
 html_title = project
 
-url_path = 'docs/dbal/en/latest/'
+url_path = 'docs/dbal'
 
 # For sitemap extension
-html_baseurl = 'https://crate.io/%s' % url_path
+html_baseurl = 'https://crate.io/%s/' % url_path
 
+# For rel="canonical" links
 html_theme_options.update({
-    'canonical_url_path': url_path, # For rel="canonical" links
+    'canonical_url_path': '%s/en/latest/' % url_path,
 })

--- a/src/crate/theme/rtd/conf/fake.py
+++ b/src/crate/theme/rtd/conf/fake.py
@@ -24,11 +24,13 @@ from crate.theme.rtd.conf import *
 project = u'CrateDB Fake Docs'
 html_title = project
 
-url_path = 'docs/fake/en/latest/'
+url_path = 'docs/fake'
 
 # For sitemap extension
-html_baseurl = 'https://crate.io/%s' % url_path
+html_baseurl = 'https://crate.io/%s/' % url_path
 
+# For rel="canonical" links
 html_theme_options.update({
-    'canonical_url_path': url_path, # For rel="canonical" links
+    'canonical_url_path': '%s/en/latest/' % url_path,
 })
+

--- a/src/crate/theme/rtd/conf/jdbc.py
+++ b/src/crate/theme/rtd/conf/jdbc.py
@@ -24,11 +24,12 @@ from crate.theme.rtd.conf import *
 project = u'CrateDB JDBC'
 html_title = project
 
-url_path = 'docs/jdbc/en/latest/'
+url_path = 'docs/jdbc'
 
 # For sitemap extension
-html_baseurl = 'https://crate.io/%s' % url_path
+html_baseurl = 'https://crate.io/%s/' % url_path
 
+# For rel="canonical" links
 html_theme_options.update({
-    'canonical_url_path': url_path, # For rel="canonical" links
+    'canonical_url_path': '%s/en/latest/' % url_path,
 })

--- a/src/crate/theme/rtd/conf/npgsql.py
+++ b/src/crate/theme/rtd/conf/npgsql.py
@@ -24,11 +24,12 @@ from crate.theme.rtd.conf import *
 project = u'CrateDB Npgsql'
 html_title = project
 
-url_path = 'docs/npgsql/en/latest/'
+url_path = 'docs/npgsql'
 
 # For sitemap extension
-html_baseurl = 'https://crate.io/%s' % url_path
+html_baseurl = 'https://crate.io/%s/' % url_path
 
+# For rel="canonical" links
 html_theme_options.update({
-    'canonical_url_path': url_path, # For rel="canonical" links
+    'canonical_url_path': '%s/en/latest/' % url_path,
 })

--- a/src/crate/theme/rtd/conf/pdo.py
+++ b/src/crate/theme/rtd/conf/pdo.py
@@ -24,11 +24,12 @@ from crate.theme.rtd.conf import *
 project = u'CrateDB PDO'
 html_title = project
 
-url_path = 'docs/pdo/en/latest/'
+url_path = 'docs/pdo'
 
 # For sitemap extension
-html_baseurl = 'https://crate.io/%s' % url_path
+html_baseurl = 'https://crate.io/%s/' % url_path
 
+# For rel="canonical" links
 html_theme_options.update({
-    'canonical_url_path': url_path, # For rel="canonical" links
+    'canonical_url_path': '%s/en/latest/' % url_path,
 })

--- a/src/crate/theme/rtd/conf/python.py
+++ b/src/crate/theme/rtd/conf/python.py
@@ -24,11 +24,12 @@ from crate.theme.rtd.conf import *
 project = u'CrateDB Python'
 html_title = project
 
-url_path = 'docs/python/en/latest/'
+url_path = 'docs/python'
 
 # For sitemap extension
-html_baseurl = 'https://crate.io/%s' % url_path
+html_baseurl = 'https://crate.io/%s/' % url_path
 
+# For rel="canonical" links
 html_theme_options.update({
-    'canonical_url_path': url_path, # For rel="canonical" links
+    'canonical_url_path': '%s/en/latest/' % url_path,
 })

--- a/src/crate/theme/rtd/conf/sql_99.py
+++ b/src/crate/theme/rtd/conf/sql_99.py
@@ -24,11 +24,12 @@ from crate.theme.rtd.conf import *
 project = u'SQL 99'
 html_title = project
 
-url_path = 'docs/sql-99/en/latest/'
+url_path = 'docs/sql-99'
 
 # For sitemap extension
-html_baseurl = 'https://crate.io/%s' % url_path
+html_baseurl = 'https://crate.io/%s/' % url_path
 
+# For rel="canonical" links
 html_theme_options.update({
-    'canonical_url_path': url_path, # For rel="canonical" links
+    'canonical_url_path': '%s/en/latest/' % url_path,
 })


### PR DESCRIPTION
looks like Read The Docs inserts [language](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language) and [version](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-version) information into the build environment, which makes sense. but it was causing the custom sitemap URLs to have double `en/` components

this PR fixes that problem by changing how project-specific URLs are built, making explicit use of `language` and `version`, as well as setting an explicit [sitemap URL scheme](https://pypi.org/project/sphinx-sitemap/#customizing-the-url-scheme)

everything seems to work locally. but will have to test once a new theme version is cut