### PR TITLE
Excluded images from external link indicator

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Unreleased
 
 - Dropped unnecessary versioned sphinx requirement specified by docs project
 - Changed url for `Try CrateDB` to the CrateDB Cloud anchor
+- Excluded images from external link indicator
 
 
 2020/09/02 0.10.15

--- a/src/crate/theme/rtd/crate/static/css/custom.css
+++ b/src/crate/theme/rtd/crate/static/css/custom.css
@@ -928,7 +928,7 @@ header.header-nav {
 }
 
 /* external links indicator */
-#main-content .col-md-8 [href^="http"]:not([href*="https://crate.io"]):not([href*="go.cratedb.com"]):not([href*="cdn.crate.io"]):not([href*="wpengine.com"]):not([href^="#"]):not([href^="/"]):not(.cr-fb-link):not(.btn):not(.cr-box-imgLink):not(.cr-feature-imgLink):not(.cr-press-title):not(.cr-img-single):not(.cr-docs-link) {
+#main-content .col-md-8 [href^="http"]:not([href*="https://crate.io"]):not([href*="go.cratedb.com"]):not([href*="cdn.crate.io"]):not([href*="wpengine.com"]):not([href^="#"]):not([href^="/"]):not(.image-reference):not(.cr-docs-link) {
   background: url(https://crate.io/wp-content/themes/crate/img/icon_link_external.svg) center left no-repeat;
   padding-left: 20px;
   margin-left: 2px;


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

This fixes the external link indicator for external images that open in a new window

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
