### PR TITLE
changed link to createdb-cloud tab

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Unreleased
 ----------
 
 - Dropped unnecessary versioned sphinx requirement specified by docs project
+- Changed url for `Try CrateDB` to the CrateDB Cloud anchor
 
 
 2020/09/02 0.10.15

--- a/src/crate/theme/rtd/crate/navbar.html
+++ b/src/crate/theme/rtd/crate/navbar.html
@@ -48,7 +48,7 @@
             </ul>
           </li>
           <li class="navlink w-nav-link menu-item"><a href="https://crate.io/blog/">Blog</a></li>
-          <li class="btn-link w-nav-link menu-item"><a href="https://crate.io/download/">Try CrateDB</a></li>
+          <li class="btn-link w-nav-link menu-item"><a href="https://crate.io/download/#cratedb-cloud">Try CrateDB</a></li>
         </ul>
       </nav>
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Since we want to push cratedb-cloud a bit more, the `Try CrateDB` link in the header should directly open the Cloud tab

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
