### PR TITLE
Added WordPress navi as edge side include via Varnish

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ CHANGES for Crate.io Documentation Theme
 Unreleased
 ----------
 
+- Added WordPress navi as edge side include via Varnish
+
 2020/10/06 0.10.17
 ------------------
 

--- a/src/crate/theme/rtd/crate/footer.html
+++ b/src/crate/theme/rtd/crate/footer.html
@@ -2,75 +2,81 @@
   <div class="w-container">
     <div class="w-clearfix">
       <div class="w-row mobileAlign">
-        <div class="w-col w-col-2 footer-menu">
-          <p class="menu-Label">Product</p>
-          <ul class="vertical-menu">
-            <li class="footer-listitem-new"><a href="https://crate.io/products/cratedb/">CrateDB</a></li>
-            <li class="footer-listitem-new"><a href="https://crate.io/products/cratedb-editions/">CrateDB Editions</a></li>
-            <li class="footer-listitem-new"><a href="https://crate.io/products/cratedb-cloud/">CrateDB Cloud</a></li>
-            <li class="footer-listitem-new"><a href="https://crate.io/pricing/">Pricing</a></li>
-            <li class="footer-listitem-new"><a href="https://crate.io/download/">Get CrateDB</a></li>
-          </ul>
-        </div>
-        
-        <div class="w-col w-col-2 footer-menu">
-          <p class="menu-Label">Use Cases</p>
-          <ul class="vertical-menu">
-            <li class="footer-listitem-new"><a href="https://crate.io/customers/">Customers</a></li>
-            <li class="footer-listitem-new"><a href="https://crate.io/use-cases/">Use Cases</a></li>
-            <li class="footer-listitem-new"><a href="https://crate.io/use-cases/iot-sensor-data">IoT & Sensors</a></li>
-            <li class="footer-listitem-new"><a href="https://crate.io/use-cases/time-series/">Time Series</a></li>
-            <li class="footer-listitem-new"><a href="https://crate.io/use-cases/geospatial-analytics/">Geospatial Tracking</a></li>
-            <li class="footer-listitem-new"><a href="https://crate.io/use-cases/cyber-security/">Cybersecurity</a></li>
-          </ul>
-        </div>
-        
-        <div class="w-col w-col-2 footer-menu">
-          <p class="menu-Label">Resources</p>
-          <ul class="vertical-menu">
-            <li class="footer-listitem-new"><a href="https://crate.io/resources/">Resource Library</a></li>
-            <li class="footer-listitem-new"><a href="https://crate.io/blog/">Blog</a></li>
-            <li class="footer-listitem-new"><a href="https://crate.io/events/">Events</a></li>
-            <li class="footer-listitem-new"><a href="https://crate.io/community/">Community</a></li>
-            <li class="footer-listitem-new"><a href="https://crate.io/community/contribute/">Contribute</a></li>
-            <li class="footer-listitem-new"><a target="_blank" rel="noopener noreferrer" href="https://github.com/crate/crate">Github</a></li>
-          </ul>
-        </div>
-        <div class="w-col w-col-2 footer-menu">
-          <p class="menu-Label">Documentation</p>
-          <ul class="vertical-menu">
-            <li class="footer-listitem-new "><a href="https://crate.io/docs/">Get started</a></li>
-            <li class="footer-listitem-new"><a href="https://crate.io/docs/crate/reference/en/latest/">Full References</a></li>
-            <li class="footer-listitem-new "><a href="https://crate.io/docs/crate/guide/en/latest/">User Guide</a></li>
-            <li class="footer-listitem-new"><a href="https://crate.io/support/">Support</a></li>
-            <li class="footer-listitem-new"><a href="https://crate.io/docs/sql-99/en/latest">SQL 99 Docs</a>
-          </ul>
-        </div>
-        <div class="w-col w-col-2 footer-menu">
-          <p class="menu-Label">Company</p>
-          <ul class="vertical-menu">
-            <li class="footer-listitem-new "><a href="https://crate.io/about/">About us</a></li>
-            <li class="footer-listitem-new"><a href="https://crate.io/jobs/">Jobs</a></li>
-            <li class="footer-listitem-new"><a href="https://crate.io/partner/">Partners</a></li>
-            <li class="footer-listitem-new "><a href="https://crate.io/press/">Press</a></li>
-            <li class="footer-listitem-new"><a href="https://crate.io/contact/">Contact</a></li>
-          </ul>
-        </div>
-        <div class="w-col w-col-2">
-          <ul class="footer-list w-list-unstyled" style="margin-top: 0; padding-left: 0;">
-            <div class="mobileHoriztonalMenu">
-              <li class="footer-listitem-new"><a href="https://crate.io/legal/">Legal</a></li>
-              <li class="footer-listitem-new"><a href="https://crate.io/legal/privacy-policy/">Privacy Policy</a></li>
-              <li class="footer-listitem-new"><a href="https://crate.io/legal/imprint/">Imprint</a></li>
-              
-            </div>
-            <li class="footer-listitem link-list">
-              <a class="footer-link-eu w-inline-block" href="/erdf/">
-                <img class="logo-eu" sizes="100px" src="{{ pathto('_static', 1) }}/images/logo-eu-optimized-1.jpg" width="101">
-              </a>
-            </li>
-          </ul>
-        </div>
+
+        <esi:remove>
+          <div class="w-col w-col-2 footer-menu">
+            <p class="menu-Label">Product</p>
+            <ul class="vertical-menu">
+              <li class="footer-listitem-new"><a href="https://crate.io/products/cratedb/">CrateDB</a></li>
+              <li class="footer-listitem-new"><a href="https://crate.io/products/cratedb-editions/">CrateDB Editions</a></li>
+              <li class="footer-listitem-new"><a href="https://crate.io/products/cratedb-cloud/">CrateDB Cloud</a></li>
+              <li class="footer-listitem-new"><a href="https://crate.io/pricing/">Pricing</a></li>
+              <li class="footer-listitem-new"><a href="https://crate.io/download/">Get CrateDB</a></li>
+            </ul>
+          </div>
+          
+          <div class="w-col w-col-2 footer-menu">
+            <p class="menu-Label">Use Cases</p>
+            <ul class="vertical-menu">
+              <li class="footer-listitem-new"><a href="https://crate.io/customers/">Customers</a></li>
+              <li class="footer-listitem-new"><a href="https://crate.io/use-cases/">Use Cases</a></li>
+              <li class="footer-listitem-new"><a href="https://crate.io/use-cases/iot-sensor-data">IoT & Sensors</a></li>
+              <li class="footer-listitem-new"><a href="https://crate.io/use-cases/time-series/">Time Series</a></li>
+              <li class="footer-listitem-new"><a href="https://crate.io/use-cases/geospatial-analytics/">Geospatial Tracking</a></li>
+              <li class="footer-listitem-new"><a href="https://crate.io/use-cases/cyber-security/">Cybersecurity</a></li>
+            </ul>
+          </div>
+          
+          <div class="w-col w-col-2 footer-menu">
+            <p class="menu-Label">Resources</p>
+            <ul class="vertical-menu">
+              <li class="footer-listitem-new"><a href="https://crate.io/resources/">Resource Library</a></li>
+              <li class="footer-listitem-new"><a href="https://crate.io/blog/">Blog</a></li>
+              <li class="footer-listitem-new"><a href="https://crate.io/events/">Events</a></li>
+              <li class="footer-listitem-new"><a href="https://crate.io/community/">Community</a></li>
+              <li class="footer-listitem-new"><a href="https://crate.io/community/contribute/">Contribute</a></li>
+              <li class="footer-listitem-new"><a target="_blank" rel="noopener noreferrer" href="https://github.com/crate/crate">Github</a></li>
+            </ul>
+          </div>
+          <div class="w-col w-col-2 footer-menu">
+            <p class="menu-Label">Documentation</p>
+            <ul class="vertical-menu">
+              <li class="footer-listitem-new "><a href="https://crate.io/docs/">Get started</a></li>
+              <li class="footer-listitem-new"><a href="https://crate.io/docs/crate/reference/en/latest/">Full References</a></li>
+              <li class="footer-listitem-new "><a href="https://crate.io/docs/crate/guide/en/latest/">User Guide</a></li>
+              <li class="footer-listitem-new"><a href="https://crate.io/support/">Support</a></li>
+              <li class="footer-listitem-new"><a href="https://crate.io/docs/sql-99/en/latest">SQL 99 Docs</a>
+            </ul>
+          </div>
+          <div class="w-col w-col-2 footer-menu">
+            <p class="menu-Label">Company</p>
+            <ul class="vertical-menu">
+              <li class="footer-listitem-new "><a href="https://crate.io/about/">About us</a></li>
+              <li class="footer-listitem-new"><a href="https://crate.io/jobs/">Jobs</a></li>
+              <li class="footer-listitem-new"><a href="https://crate.io/partner/">Partners</a></li>
+              <li class="footer-listitem-new "><a href="https://crate.io/press/">Press</a></li>
+              <li class="footer-listitem-new"><a href="https://crate.io/contact/">Contact</a></li>
+            </ul>
+          </div>
+          <div class="w-col w-col-2">
+            <ul class="footer-list w-list-unstyled" style="margin-top: 0; padding-left: 0;">
+              <div class="mobileHoriztonalMenu">
+                <li class="footer-listitem-new"><a href="https://crate.io/legal/">Legal</a></li>
+                <li class="footer-listitem-new"><a href="https://crate.io/legal/privacy-policy/">Privacy Policy</a></li>
+                <li class="footer-listitem-new"><a href="https://crate.io/legal/imprint/">Imprint</a></li>
+                
+              </div>
+              <li class="footer-listitem link-list">
+                <a class="footer-link-eu w-inline-block" href="/erdf/">
+                  <img class="logo-eu" sizes="100px" src="{{ pathto('_static', 1) }}/images/logo-eu-optimized-1.jpg" width="101">
+                </a>
+              </li>
+            </ul>
+          </div>
+        </esi:remove>
+        <!--esi
+          <esi:include src="https://crate.io/navi-footer.php" />
+          -->
       </div>
       <div class="w-row">
         <a class="brand footer-brand w-inline-block" href="/">

--- a/src/crate/theme/rtd/crate/navbar.html
+++ b/src/crate/theme/rtd/crate/navbar.html
@@ -11,44 +11,49 @@
           <span class="arrow"></span>
         </div>
         <ul id="menu-top-navigation" class="menu">
-          <li class="navlink w-nav-link menu-item menu-item-has-children">
-            <a href="https://crate.io/products/">Products</a>
-            <ul class="sub-menu">
-              <li class="menu-item"><a href="https://crate.io/products/cratedb/">CrateDB</a></li>
-              <li class="menu-item"><a href="https://crate.io/products/cratedb-cloud/">CrateDB Cloud</a></li>
-              <li class="menu-item"><a href="https://crate.io/docs/">Get started</a></li>
-            </ul>
-          </li>
-          <li class="navlink w-nav-link menu-item menu-item-has-children">
-            <a href="https://crate.io/customers/">Customers</a>
-            <ul class="sub-menu">
-              <li class="menu-item"><a href="https://crate.io/use-cases/">Use Cases</a></li>
-            </ul>
-          </li>
-          <li class="navlink w-nav-link menu-item"><a href="https://crate.io/cratedb-comparison/">Compare</a></li>
-           <li class="navlink w-nav-link menu-item menu-item-has-children">
-            <a href="https://crate.io/about/">Company</a>
-            <ul class="sub-menu">
-              <li class="menu-item"><a href="https://crate.io/partner/">Partners</a></li>
-              <li class="menu-item"><a href="https://crate.io/jobs/">Careers</a></li>
-              <li class="menu-item"><a href="https://crate.io/a/press-category/in-the-news/">Newsroom</a></li>
-              <li class="menu-item"><a href="https://crate.io/events/">Events</a></li>
-              <li class="menu-item"><a href="https://crate.io/a/tag/awards/">Awards</a></li>
-              <li class="menu-item"><a href="https://crate.io/contact/">Contact us</a></li>
-             </ul>
-          </li>
-          <li class="navlink w-nav-link menu-item menu-item-has-children">
-            <a href="https://crate.io/resources/">Resources</a>
-            <ul class="sub-menu">
-              <li class="menu-item"><a href="https://crate.io/resources/webinars/">Webinars</a></li>
-              <li class="menu-item"><a href="https://crate.io/resources/">Content Library</a></li>
-              <li class="menu-item"><a href="https://crate.io/resources/videos/">Videos</a></li>
-              <li class="menu-item"><a href="https://crate.io/community/">Community</a></li>
-              <li class="menu-item"><a href="https://crate.io/docs/crate/reference/en/latest/">Documentation</a></li>
-            </ul>
-          </li>
-          <li class="navlink w-nav-link menu-item"><a href="https://crate.io/blog/">Blog</a></li>
-          <li class="btn-link w-nav-link menu-item"><a href="https://crate.io/download/#cratedb-cloud">Try CrateDB</a></li>
+          <esi:remove>
+            <li class="navlink w-nav-link menu-item menu-item-has-children">
+              <a href="https://crate.io/products/">Products</a>
+              <ul class="sub-menu">
+                <li class="menu-item"><a href="https://crate.io/products/cratedb/">CrateDB</a></li>
+                <li class="menu-item"><a href="https://crate.io/products/cratedb-cloud/">CrateDB Cloud</a></li>
+                <li class="menu-item"><a href="https://crate.io/docs/">Get started</a></li>
+              </ul>
+            </li>
+            <li class="navlink w-nav-link menu-item menu-item-has-children">
+              <a href="https://crate.io/customers/">Customers</a>
+              <ul class="sub-menu">
+                <li class="menu-item"><a href="https://crate.io/use-cases/">Use Cases</a></li>
+              </ul>
+            </li>
+            <li class="navlink w-nav-link menu-item"><a href="https://crate.io/cratedb-comparison/">Compare</a></li>
+             <li class="navlink w-nav-link menu-item menu-item-has-children">
+              <a href="https://crate.io/about/">Company</a>
+              <ul class="sub-menu">
+                <li class="menu-item"><a href="https://crate.io/partner/">Partners</a></li>
+                <li class="menu-item"><a href="https://crate.io/jobs/">Careers</a></li>
+                <li class="menu-item"><a href="https://crate.io/a/press-category/in-the-news/">Newsroom</a></li>
+                <li class="menu-item"><a href="https://crate.io/events/">Events</a></li>
+                <li class="menu-item"><a href="https://crate.io/a/tag/awards/">Awards</a></li>
+                <li class="menu-item"><a href="https://crate.io/contact/">Contact us</a></li>
+               </ul>
+            </li>
+            <li class="navlink w-nav-link menu-item menu-item-has-children">
+              <a href="https://crate.io/resources/">Resources</a>
+              <ul class="sub-menu">
+                <li class="menu-item"><a href="https://crate.io/resources/webinars/">Webinars</a></li>
+                <li class="menu-item"><a href="https://crate.io/resources/">Content Library</a></li>
+                <li class="menu-item"><a href="https://crate.io/resources/videos/">Videos</a></li>
+                <li class="menu-item"><a href="https://crate.io/community/">Community</a></li>
+                <li class="menu-item"><a href="https://crate.io/docs/crate/reference/en/latest/">Documentation</a></li>
+              </ul>
+            </li>
+            <li class="navlink w-nav-link menu-item"><a href="https://crate.io/blog/">Blog</a></li>
+            <li class="btn-link w-nav-link menu-item"><a href="https://crate.io/download/#cratedb-cloud">Try CrateDB</a></li>
+          </esi:remove>
+          <!--esi
+            <esi:include src="https://crate.io/navi-header.php" />
+            -->
         </ul>
       </nav>
 

--- a/src/crate/theme/rtd/crate/static/css/custom.css
+++ b/src/crate/theme/rtd/crate/static/css/custom.css
@@ -11,6 +11,7 @@ a:focus {
   text-decoration: none;
 }
 
+.cr-menu-btn,
 .btn,
 .btn-link a {
   border-radius: 0;
@@ -26,6 +27,7 @@ a:focus {
   padding: 16px 28px;
 }
 
+.cr-menu-btn a,
 .btn-primary,
 .btn-link a {
   border: 2px solid #55D4F5;
@@ -35,6 +37,7 @@ a:focus {
   text-decoration: none;
 }
 
+.cr-menu-btn a:hover,
 .btn-primary:hover,
 .btn-link a:hover {
   color: #1CC8F3;
@@ -88,6 +91,11 @@ a:focus {
   align-items: center;
 }
 
+#menu-main-navigation li > ul li.w-nav-link {
+    padding: 0;
+    display: block;
+}
+
 .brand.w-nav-brand {
   margin-right: auto;
 }
@@ -102,6 +110,7 @@ a:focus {
   text-decoration: none;
 }
 
+.cr-menu-btn a,
 .main-nav .btn-link a {
   padding: 8px 16px !important;
 }
@@ -360,6 +369,14 @@ body .mm-menu .navbar-nav {
 
   footer.footer .footer-brand {
     display: none;
+  }
+
+  .footer-list li {
+    display: inline;
+  }
+
+  .footer-listitem.link-list {
+    display: block;
   }
 }
 
@@ -932,4 +949,24 @@ header.header-nav {
   background: url(https://crate.io/wp-content/themes/crate/img/icon_link_external.svg) center left no-repeat;
   padding-left: 20px;
   margin-left: 2px;
+}
+
+/* hide menuitem in docs */
+.cr-menu-hide {
+  display: none !important;
+}
+
+footer .menu-item a {
+  color: #000;
+}
+
+.w-cr-footer .vertical-menu li:first-child {
+    margin-bottom: 16px;
+    font-weight: bold;
+}
+
+.w-cr-footer .vertical-menu li:first-child a:hover {
+    cursor: default;
+    color: #000;
+    opacity: 1;
 }


### PR DESCRIPTION
adjusted a bit of css to keep the current layout and added the <esi> tags in the nav-files

## Summary of the changes / Why this is an improvement

This will load the header and footer navigation from crate.io's WordPress installation dynamically through fastly. If something changes there, the docs navi should automatically be updated as well. Please test on a single repo first, because there was no way to test the [esi stuff](https://varnish-cache.org/docs/6.5/users-guide/esi.html?highlight=esi) localhost or on staging.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
