### PR TITLE
Upgrade to new build 0.4.0

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,25 @@
+name: docs
+on:
+  pull_request: ~
+  push:
+    branches:
+      - master
+
+jobs:
+  documentation:
+    name: Build docs on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Build docs
+        run: |
+          cd docs && make check

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .build
 .clone
-.crate-docs-build
+.crate-docs
 .dist
 .DS_Store
 .env

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,14 @@
+---
+pull_request_rules:
+  - actions:
+      merge:
+        method: rebase
+        rebase_fallback: null
+        strict: true
+    conditions:
+      - label=ready-to-merge
+      - '#approved-reviews-by>=1'
+      - status-success~=continuous-integration/travis-ci
+      - status-success~=Build docs
+      - status-success~=docs/readthedocs.org
+    name: default

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,19 +24,11 @@ code: &code
   script:
     - make build
 
-docs: &docs
-  stage: "Documentation"
-  script:
-    - cd docs && make check
-
 matrix:
   include:
 
     - <<: *code
       <<: *linux
-
-    - <<: *docs
-      <<: *linux
-    - <<: *docs
+    - <<: *code
       <<: *osx
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -26,8 +26,8 @@
 DOCS_DIR      := docs
 TOP_DIR       := ..
 BUILD_JSON    := build.json
-BUILD_REPO    := https://github.com/crate/crate-docs-build.git
-CLONE_DIR     := .crate-docs-build
+BUILD_REPO    := https://github.com/crate/crate-docs.git
+CLONE_DIR     := .crate-docs
 SRC_DIR       := $(CLONE_DIR)/src
 SELF_SRC      := $(TOP_DIR)/src
 SELF_MAKEFILE := $(SELF_SRC)/rules.mk

--- a/docs/build.json
+++ b/docs/build.json
@@ -1,5 +1,5 @@
 {
   "schemaVersion": 1,
   "label": "docs build",
-  "message": "0.3.3"
+  "message": "0.4.0"
 }


### PR DESCRIPTION
this PR is a sub-task of https://github.com/crate/tech-writing-domain/issues/353

changes:

- Pins the docs-build to 0.4.0
- Adds a new GitHub Actions workflow for testing the docs
- Modifies the Travis CI configuration to remove the docs tests (and also extend the existing code tests to macOS, as the configuration was already there)
- Adds a Mergify configuration