### PR TITLE
Improves list styling by adding extra margin

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ CHANGES for Crate.io Documentation Theme
 Unreleased
 ----------
 
+- Add left-margin to all lists
+- Fix paragraph margins for lists using the "open" class
+
 
 2020/12/01 0.12.0
 -----------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,6 +6,33 @@ Crate Docs Theme
 
 This documentation is a stub.
 
+.. NOTE::
+
+    This is a friendly note.
+
+    This is a second paragraph also notifying you that this is a note.
+
+What is a list?
+
+* It has bullet points like this one
+* The list items are spaced close together like subsequent lines in a paragraph
+* Typically the items are short and are not terminated with a period
+
+An open list is quite different:
+
+.. rst-class:: open
+
+* Notice how this sentence is terminated with a period.
+
+  And there's a second paragraph too.
+
+* This is the second item. Notice how it is separated from the first item like
+  a regular paragraph would be.
+
+This is a regular paragraph and not a list item.
+
+.. rubric:: Table of Contents
+
 .. toctree::
     :maxdepth: 1
 

--- a/src/crate/theme/rtd/crate/static/css/crateio.css
+++ b/src/crate/theme/rtd/crate/static/css/crateio.css
@@ -113,14 +113,15 @@ a:hover {
   color: #55d4f5;
 }
 
-ul {
+ul, ol {
   margin-top: 0px;
-  margin-bottom: 10px;
+  margin-bottom: 16px;
+  margin-left: 16px;
   padding-left: 1em;
 }
 
 blockquote {
-  margin-bottom: 10px;
+  margin-bottom: 16px;
   padding: 10px 20px;
   border-left-color: #000;
   font-size: 24px;
@@ -1300,8 +1301,8 @@ a.learn-more-link, .wrapper-teaser-img p {
 }
 
 .admonition {
-  margin-top: 10px;
-  margin-bottom: 10px;
+  margin-top: 16px;
+  margin-bottom: 16px;
   padding: 7px;
 }
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Specifically:

- Add left-margin to all lists
- Fix paragraph margins for lists using the "open" class

I also added some dummy text to the demo Sphinx project so you can test and preview the changes. Here's what it looks like on mine with the changes in place.

![image](https://user-images.githubusercontent.com/23469/103902092-54d19700-50fa-11eb-9ab9-2cae2d277351.png)
