### PR TITLE
Fix styling of lists in admonitions, rework Sphinx project for testing

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,27 +1,72 @@
 .. _index:
 
-================
-Crate Docs Theme
-================
+==========
+Page Title
+==========
 
 .. meta::
     :description lang=en:
         This is the meta description, it should be between 150-300 characters.
         Meta descriptions are used for display but not for ranking.
 
-This documentation is a stub.
+This is a sample documentation project that can be used for visually testing
+the theme.
+
+How to use this documentation:
+
+- Verify that each page element displays correctly. Some page elements identify
+  themselves (e.g., the :ref:`index`) and some elements describe how they ought
+  to appear (e.g., the :ref:`first admonition <first-admonition>`).
+
+How to improve this documentation:
+
+- If you notice any bugs, please `report an issue`_ or create a PR to fix them.
+
+- Add page elements and use the available text to describe how the element
+  should be displayed.
+
 
 .. NOTE::
 
-    This is a friendly note.
+    For help building this documentation as a part of your testing and *Quality
+    Assurance* (QA) workflow, see the `developer guide`_.
 
-    This is a second paragraph also notifying you that this is a note.
+.. rubric:: Table of Contents
 
-What is a list?
+.. contents::
+   :local:
+
+
+.. _top-level-heading:
+
+Top-level heading
+=================
+
+.. _first-admonition:
+
+.. NOTE::
+
+    This is the first paragraph of a note admonition. The admonition is
+    visually set off from the rest of the content and has a colored background.
+
+    This is a second paragraph. There is an icon to the left of both paragraphs
+    that represents the concept of a "note".
+
+
+.. _second-level-heading:
+
+Second-level heading
+--------------------
+
+.. _closed-list:
+
+This is a closed list:
 
 * It has bullet points like this one
 * The list items are spaced close together like subsequent lines in a paragraph
 * Typically the items are short and are not terminated with a period
+
+.. _open-list:
 
 An open list is quite different:
 
@@ -36,9 +81,49 @@ An open list is quite different:
 
 This is a regular paragraph and not a list item.
 
-.. rubric:: Table of Contents
+
+.. _third-level-heading:
+
+Third-level heading
+~~~~~~~~~~~~~~~~~~~
+
+.. NOTE::
+
+    Here's a regular list:
+
+    - This is the first list item
+    - The list items are spaced close together like subsequent lines in a
+      paragraph
+    - This list is styled the same as the :ref:`closed list <closed-list>`
+      above
+
+    This is an open list:
+
+     .. rst-class:: open
+
+     - This list looks the same as the :ref:`open list <closed-list>` above
+
+     - The list items are separated as if they were separate paragraphs
+
+
+.. _fourth-level-heading:
+
+Fourth-level heading
+^^^^^^^^^^^^^^^^^^^^
 
 .. toctree::
     :maxdepth: 1
 
     subpage
+
+
+.. _fifth-level-heading:
+
+Fifth-level heading
+...................
+
+This is the deepest heading level we support.
+
+
+.. _developer guide: https://github.com/crate/crate-docs-theme/blob/master/DEVELOP.rst#make-changes
+.. _report an issue: https://github.com/crate/crate-docs/issues/new

--- a/src/crate/theme/rtd/crate/static/css/custom.css
+++ b/src/crate/theme/rtd/crate/static/css/custom.css
@@ -608,7 +608,7 @@ div.sidebar {
   margin-bottom: 0;
 }
 
-.wrapper-content-right ul, 
+.wrapper-content-right ul,
 .wrapper-content-right ol {
   margin-bottom: 16px;
   margin-left: 16px;
@@ -1195,7 +1195,7 @@ div.sidebar {
 }
 
 /* preload image */
-#ratingForm { 
+#ratingForm {
   background: url('../images/cr-star-full.svg') no-repeat -9999px -9999px;
 }
 
@@ -1256,7 +1256,7 @@ div.sidebar {
   min-width: 170px;
 }
 
-#ratingVote:disabled, 
+#ratingVote:disabled,
 #ratingVote[disabled] {
   color: #ccc;
   display: none;
@@ -1383,4 +1383,12 @@ footer .footer-listitem-new:first-child a {
     margin: 8px 0;
   }
 
+}
+
+div.admonition ul.simple p {
+    padding: 0;
+}
+
+div.admonition ul.open p {
+    padding: 0 0 10px 0;
 }


### PR DESCRIPTION
Specifically:

- Remove the CSS rules that expand bullet point padding when they appear inside
  an admonition.

  There is no reason for this that I can figure out, it looks bad, it is
  inconsistent with list styling outside of admonitions, and it removes the
  distinction between closed lists and open lists (see "Lists" section in
  https://github.com/crate/crate-docs/blob/main/style/rst.rst)

- Added some test content to `docs/index.rst` that allows you to view how
  different lists are styled in different contexts.

  Additionally, I reworked the rest of `docs/index.rst` to make it clear this
  is a sample Sphinx project we can use to visually test the theme.
