### PR TITLE
Fix sidebar TOC, plus minor code reformatting 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,6 @@
-========================================
-CHANGES for Crate.io Documentation Theme
-========================================
+=======
+CHANGES
+=======
 
 
 Unreleased
@@ -8,6 +8,9 @@ Unreleased
 
 - Preloading the full star of the rating system to prevent empty stars
 - Added a note about ``custom.css`` and ``custom.js``
+- Fix sidebar TOC . Previously, Sphinx was not expanding the sidebar TOC for
+  both how-to projects.
+
 
 2021/02/03 0.13.1
 -----------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,10 +1,10 @@
 from crate.theme.rtd.conf.fake import *
 
 html_context = {
-  "display_github": True,
-  "github_user": "crate",
-  "github_repo": "crate-docs-theme",
-  "github_version": "master",
-  "conf_py_path": "/docs/",
-  "source_suffix": source_suffix,
+    "display_github": True,
+    "github_user": "crate",
+    "github_repo": "crate-docs-theme",
+    "github_version": "master",
+    "conf_py_path": "/docs/",
+    "source_suffix": source_suffix,
 }

--- a/setup.py
+++ b/setup.py
@@ -24,38 +24,38 @@ from importlib import machinery
 from setuptools import setup, find_packages
 
 pwd = os.path.join(os.path.dirname(__file__))
-filepath = os.path.join(pwd, 'src', 'crate', 'theme', 'rtd', '__init__.py')
-version = machinery.SourceFileLoader(
-    'theme', filepath).load_module().__version__
+filepath = os.path.join(pwd, "src", "crate", "theme", "rtd", "__init__.py")
+version = machinery.SourceFileLoader("theme", filepath).load_module().__version__
 
-setup(name='crate-docs-theme',
-      version=version,
-      description='Crate Docs Theme',
-      long_description='A Sphinx theme for the Crate Documentation',
-      classifiers=[
-          "Intended Audience :: Developers",
-          "License :: OSI Approved :: Apache Software License",
-          "Operating System :: OS Independent",
-          "Programming Language :: Python",
-          "Programming Language :: Python :: 3",
-          "Programming Language :: Python :: 3.6",
-          "Programming Language :: Python :: 3.7",
-          "Topic :: Software Development :: Documentation",
-      ],
-      author='Crate.IO GmbH',
-      author_email='office@crate.io',
-      url='https://github.com/crate/crate-docs-theme',
-      keywords='crate docs sphinx readthedocs',
-      license='Apache License 2.0',
-      packages=find_packages('src'),
-      package_dir={'':'src'},
-      namespace_packages=['crate'],
-      include_package_data=True,
-      zip_safe=False,
-      install_requires=[
-          'Sphinx>=1.8.5,<4',
-          'sphinxcontrib-plantuml==0.19',
-          'sphinx_sitemap==2.2.0',
-      ],
-      python_requires=">=3.7",
+setup(
+    name="crate-docs-theme",
+    version=version,
+    description="Crate Docs Theme",
+    long_description="A Sphinx theme for the Crate Documentation",
+    classifiers=[
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Topic :: Software Development :: Documentation",
+    ],
+    author="Crate.IO GmbH",
+    author_email="office@crate.io",
+    url="https://github.com/crate/crate-docs-theme",
+    keywords="crate docs sphinx readthedocs",
+    license="Apache License 2.0",
+    packages=find_packages("src"),
+    package_dir={"": "src"},
+    namespace_packages=["crate"],
+    include_package_data=True,
+    zip_safe=False,
+    install_requires=[
+        "Sphinx>=1.8.5,<4",
+        "sphinxcontrib-plantuml==0.19",
+        "sphinx_sitemap==2.2.0",
+    ],
+    python_requires=">=3.7",
 )

--- a/src/crate/__init__.py
+++ b/src/crate/__init__.py
@@ -23,7 +23,9 @@
 
 try:
     import pkg_resources
+
     pkg_resources.declare_namespace(__name__)
 except ImportError:
     import pkgutil
+
     __path__ = pkgutil.extend_path(__path__, __name__)

--- a/src/crate/theme/rtd/__init__.py
+++ b/src/crate/theme/rtd/__init__.py
@@ -28,26 +28,31 @@ VERSION = (0, 13, 1)
 __version__ = ".".join(str(v) for v in VERSION)
 __version_full__ = __version__
 
+
 def get_version():
     return __version__
 
+
 def current_dir():
     return os.path.abspath(os.path.dirname(__file__))
+
 
 def get_html_theme_path():
     """Return list of HTML theme paths."""
     return [current_dir()]
 
+
 def get_html_static_path():
     """Return list of HTML static paths."""
     current_dir = current_dir()
     return [
-        os.path.join(current_dir, 'crate', 'static'),
+        os.path.join(current_dir, "crate", "static"),
     ]
+
 
 def get_html_template_path():
     """Return list of HTML template paths."""
     current_dir = current_dir()
     return [
-        os.path.join(current_dir, 'crate'),
+        os.path.join(current_dir, "crate"),
     ]

--- a/src/crate/theme/rtd/conf/__init__.py
+++ b/src/crate/theme/rtd/conf/__init__.py
@@ -22,41 +22,36 @@
 from crate.theme import rtd as theme
 from os import environ
 
-source_suffix = '.rst'
+source_suffix = ".rst"
 
-master_doc = 'index'
+master_doc = "index"
 
-exclude_patterns = ['.*', '*.lint', 'README.rst', 'requirements.txt']
-exclude_trees = ['pyenv', 'tmp', 'out', 'parts', 'clients', 'eggs']
+exclude_patterns = [".*", "*.lint", "README.rst", "requirements.txt"]
+exclude_trees = ["pyenv", "tmp", "out", "parts", "clients", "eggs"]
 
-extensions = ['sphinx_sitemap']
+extensions = ["sphinx_sitemap"]
 
 # Configure the theme
-html_theme = 'crate'
+html_theme = "crate"
 html_theme_path = theme.get_html_theme_path()
 nitpicky = True
 html_show_sourcelink = False
-html_sidebars = {'**': ['sidebar.html', 'sourcelink.html']}
+html_sidebars = {"**": ["sidebar.html", "sourcelink.html"]}
 html_theme_options = {
     # HTML navbar class (Default: "navbar") to attach to <div> element.
     # For black navbar, do "navbar navbar-inverse"
-    'navbar_class': 'navbar navbar-inverse',
-
+    "navbar_class": "navbar navbar-inverse",
     # Fix navigation bar to top of page?
     # Values: "true" (default) or "false"
-    'navbar_fixed_top': 'false',
-
-    'globaltoc_includehidden': 'true',
-
+    "navbar_fixed_top": "false",
+    "globaltoc_includehidden": "true",
     # The URL path is required because RTD does only allow root as a canonical
     # url
-    'canonical_url_path': '',
-    'canonical_url': 'https://crate.io/',
-
+    "canonical_url_path": "",
+    "canonical_url": "https://crate.io/",
     # segment analytics configuration
-    'tracking_segment_id': environ.get('TRACKING_SEGMENT_ID', ''),
-    'tracking_project': '',
-
+    "tracking_segment_id": environ.get("TRACKING_SEGMENT_ID", ""),
+    "tracking_project": "",
     # Can be used the query string of a resource URL for HTTP cache busting
     "ver": theme.get_version(),
 }
@@ -66,6 +61,7 @@ sitemap_filename = "site.xml"
 language = "en"
 version = "latest"
 sitemap_url_scheme = "{lang}{version}{link}"
+
 
 def setup(app):
     # Force the canonical URL in multiple ways
@@ -79,15 +75,19 @@ def setup(app):
     def force_canonical_url(app_inited):
         from sphinx.builders.html import StandaloneHTMLBuilder
         from sphinx.builders.epub3 import Epub3Builder
-        if (isinstance(app_inited.builder, StandaloneHTMLBuilder)
-                and not isinstance(app_inited.builder, Epub3Builder)):
+
+        if isinstance(app_inited.builder, StandaloneHTMLBuilder) and not isinstance(
+            app_inited.builder, Epub3Builder
+        ):
             try:
-                canonical_url = app_inited.builder.theme_options['canonical_url']
-                canonical_url_path = app_inited.builder.theme_options['canonical_url_path']
+                canonical_url = app_inited.builder.theme_options["canonical_url"]
+                canonical_url_path = app_inited.builder.theme_options[
+                    "canonical_url_path"
+                ]
             except KeyError:
                 return
             canonical_url = canonical_url + canonical_url_path
-            app_inited.env.config.html_context['canonical_url'] = canonical_url
-            app_inited.builder.config.html_context['canonical_url'] = canonical_url
-    app.connect('builder-inited', force_canonical_url)
+            app_inited.env.config.html_context["canonical_url"] = canonical_url
+            app_inited.builder.config.html_context["canonical_url"] = canonical_url
 
+    app.connect("builder-inited", force_canonical_url)

--- a/src/crate/theme/rtd/conf/cloud_cli.py
+++ b/src/crate/theme/rtd/conf/cloud_cli.py
@@ -19,17 +19,23 @@
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
 
+
 from crate.theme.rtd.conf import *
 
-project = u'CrateDB Cloud: Croud CLI'
+# If you update the `project` value here, you must update it in the
+# `src/crate/theme/rtd/crate/sidebartoc.html` file or else Sphinx will not
+# expand the sidebar TOC for this project.
+project = u"CrateDB Cloud: Croud CLI"
 html_title = project
 
-url_path = 'docs/cloud/cli'
+url_path = "docs/cloud/cli"
 
 # For sitemap extension
-html_baseurl = 'https://crate.io/%s/' % url_path
+html_baseurl = "https://crate.io/%s/" % url_path
 
 # For rel="canonical" links
-html_theme_options.update({
-    'canonical_url_path': '%s/en/latest/' % url_path,
-})
+html_theme_options.update(
+    {
+        "canonical_url_path": "%s/en/latest/" % url_path,
+    }
+)

--- a/src/crate/theme/rtd/conf/cloud_howtos.py
+++ b/src/crate/theme/rtd/conf/cloud_howtos.py
@@ -19,17 +19,23 @@
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
 
+
 from crate.theme.rtd.conf import *
 
-project = u'CrateDB Cloud: How-tos'
+# If you update the `project` value here, you must update it in the
+# `src/crate/theme/rtd/crate/sidebartoc.html` file or else Sphinx will not
+# expand the sidebar TOC for this project.
+project = u"CrateDB Cloud: How-tos"
 html_title = project
 
-url_path = 'docs/cloud/howtos'
+url_path = "docs/cloud/howtos"
 
 # For sitemap extension
-html_baseurl = 'https://crate.io/%s/' % url_path
+html_baseurl = "https://crate.io/%s/" % url_path
 
 # For rel="canonical" links
-html_theme_options.update({
-    'canonical_url_path': '%s/en/latest/' % url_path,
-})
+html_theme_options.update(
+    {
+        "canonical_url_path": "%s/en/latest/" % url_path,
+    }
+)

--- a/src/crate/theme/rtd/conf/cloud_reference.py
+++ b/src/crate/theme/rtd/conf/cloud_reference.py
@@ -19,17 +19,23 @@
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
 
+
 from crate.theme.rtd.conf import *
 
-project = u'CrateDB Cloud: Reference'
+# If you update the `project` value here, you must update it in the
+# `src/crate/theme/rtd/crate/sidebartoc.html` file or else Sphinx will not
+# expand the sidebar TOC for this project.
+project = u"CrateDB Cloud: Reference"
 html_title = project
 
-url_path = 'docs/cloud/reference'
+url_path = "docs/cloud/reference"
 
 # For sitemap extension
-html_baseurl = 'https://crate.io/%s/' % url_path
+html_baseurl = "https://crate.io/%s/" % url_path
 
 # For rel="canonical" links
-html_theme_options.update({
-    'canonical_url_path': '%s/en/latest/' % url_path,
-})
+html_theme_options.update(
+    {
+        "canonical_url_path": "%s/en/latest/" % url_path,
+    }
+)

--- a/src/crate/theme/rtd/conf/cloud_tutorials.py
+++ b/src/crate/theme/rtd/conf/cloud_tutorials.py
@@ -19,17 +19,23 @@
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
 
+
 from crate.theme.rtd.conf import *
 
-project = u'CrateDB Cloud: Tutorials'
+# If you update the `project` value here, you must update it in the
+# `src/crate/theme/rtd/crate/sidebartoc.html` file or else Sphinx will not
+# expand the sidebar TOC for this project.
+project = u"CrateDB Cloud: Tutorials"
 html_title = project
 
-url_path = 'docs/cloud/tutorials'
+url_path = "docs/cloud/tutorials"
 
 # For sitemap extension
-html_baseurl = 'https://crate.io/%s/' % url_path
+html_baseurl = "https://crate.io/%s/" % url_path
 
 # For rel="canonical" links
-html_theme_options.update({
-    'canonical_url_path': '%s/en/latest/' % url_path,
-})
+html_theme_options.update(
+    {
+        "canonical_url_path": "%s/en/latest/" % url_path,
+    }
+)

--- a/src/crate/theme/rtd/conf/crate_admin_ui.py
+++ b/src/crate/theme/rtd/conf/crate_admin_ui.py
@@ -19,17 +19,23 @@
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
 
+
 from crate.theme.rtd.conf import *
 
-project = u'CrateDB: Admin UI'
+# If you update the `project` value here, you must update it in the
+# `src/crate/theme/rtd/crate/sidebartoc.html` file or else Sphinx will not
+# expand the sidebar TOC for this project.
+project = u"CrateDB: Admin UI"
 html_title = project
 
-url_path = 'docs/crate/admin-ui'
+url_path = "docs/crate/admin-ui"
 
 # For sitemap extension
-html_baseurl = 'https://crate.io/%s/' % url_path
+html_baseurl = "https://crate.io/%s/" % url_path
 
 # For rel="canonical" links
-html_theme_options.update({
-    'canonical_url_path': '%s/en/latest/' % url_path,
-})
+html_theme_options.update(
+    {
+        "canonical_url_path": "%s/en/latest/" % url_path,
+    }
+)

--- a/src/crate/theme/rtd/conf/crate_clients_tools.py
+++ b/src/crate/theme/rtd/conf/crate_clients_tools.py
@@ -19,17 +19,23 @@
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
 
+
 from crate.theme.rtd.conf import *
 
-project = u'CrateDB: Clients and Tools'
+# If you update the `project` value here, you must update it in the
+# `src/crate/theme/rtd/crate/sidebartoc.html` file or else Sphinx will not
+# expand the sidebar TOC for this project.
+project = u"CrateDB: Clients and Tools"
 html_title = project
 
-url_path = 'docs/crate/clients-tools'
+url_path = "docs/crate/clients-tools"
 
 # For sitemap extension
-html_baseurl = 'https://crate.io/%s/' % url_path
+html_baseurl = "https://crate.io/%s/" % url_path
 
 # For rel="canonical" links
-html_theme_options.update({
-    'canonical_url_path': '%s/en/latest/' % url_path,
-})
+html_theme_options.update(
+    {
+        "canonical_url_path": "%s/en/latest/" % url_path,
+    }
+)

--- a/src/crate/theme/rtd/conf/crate_crash.py
+++ b/src/crate/theme/rtd/conf/crate_crash.py
@@ -19,17 +19,23 @@
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
 
+
 from crate.theme.rtd.conf import *
 
-project = u'CrateDB: Crash CLI'
+# If you update the `project` value here, you must update it in the
+# `src/crate/theme/rtd/crate/sidebartoc.html` file or else Sphinx will not
+# expand the sidebar TOC for this project.
+project = u"CrateDB: Crash CLI"
 html_title = project
 
-url_path = 'docs/crate/crash'
+url_path = "docs/crate/crash"
 
 # For sitemap extension
-html_baseurl = 'https://crate.io/%s/' % url_path
+html_baseurl = "https://crate.io/%s/" % url_path
 
 # For rel="canonical" links
-html_theme_options.update({
-    'canonical_url_path': '%s/en/latest/' % url_path,
-})
+html_theme_options.update(
+    {
+        "canonical_url_path": "%s/en/latest/" % url_path,
+    }
+)

--- a/src/crate/theme/rtd/conf/crate_howtos.py
+++ b/src/crate/theme/rtd/conf/crate_howtos.py
@@ -19,17 +19,23 @@
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
 
+
 from crate.theme.rtd.conf import *
 
-project = u'CrateDB: How-Tos'
+# If you update the `project` value here, you must update it in the
+# `src/crate/theme/rtd/crate/sidebartoc.html` file or else Sphinx will not
+# expand the sidebar TOC for this project.
+project = u"CrateDB: How-Tos"
 html_title = project
 
-url_path = 'docs/crate/howtos'
+url_path = "docs/crate/howtos"
 
 # For sitemap extension
-html_baseurl = 'https://crate.io/%s/' % url_path
+html_baseurl = "https://crate.io/%s/" % url_path
 
 # For rel="canonical" links
-html_theme_options.update({
-    'canonical_url_path': '%s/en/latest/' % url_path,
-})
+html_theme_options.update(
+    {
+        "canonical_url_path": "%s/en/latest/" % url_path,
+    }
+)

--- a/src/crate/theme/rtd/conf/crate_reference.py
+++ b/src/crate/theme/rtd/conf/crate_reference.py
@@ -19,17 +19,23 @@
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
 
+
 from crate.theme.rtd.conf import *
 
-project = u'CrateDB: Reference'
+# If you update the `project` value here, you must update it in the
+# `src/crate/theme/rtd/crate/sidebartoc.html` file or else Sphinx will not
+# expand the sidebar TOC for this project.
+project = u"CrateDB: Reference"
 html_title = project
 
-url_path = 'docs/crate/reference'
+url_path = "docs/crate/reference"
 
 # For sitemap extension
-html_baseurl = 'https://crate.io/%s/' % url_path
+html_baseurl = "https://crate.io/%s/" % url_path
 
 # For rel="canonical" links
-html_theme_options.update({
-    'canonical_url_path': '%s/en/latest/' % url_path,
-})
+html_theme_options.update(
+    {
+        "canonical_url_path": "%s/en/latest/" % url_path,
+    }
+)

--- a/src/crate/theme/rtd/conf/crate_tutorials.py
+++ b/src/crate/theme/rtd/conf/crate_tutorials.py
@@ -19,17 +19,23 @@
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
 
+
 from crate.theme.rtd.conf import *
 
-project = u'CrateDB: Tutorials'
+# If you update the `project` value here, you must update it in the
+# `src/crate/theme/rtd/crate/sidebartoc.html` file or else Sphinx will not
+# expand the sidebar TOC for this project.
+project = u"CrateDB: Tutorials"
 html_title = project
 
-url_path = 'docs/crate/tutorials'
+url_path = "docs/crate/tutorials"
 
 # For sitemap extension
-html_baseurl = 'https://crate.io/%s/' % url_path
+html_baseurl = "https://crate.io/%s/" % url_path
 
 # For rel="canonical" links
-html_theme_options.update({
-    'canonical_url_path': '%s/en/latest/' % url_path,
-})
+html_theme_options.update(
+    {
+        "canonical_url_path": "%s/en/latest/" % url_path,
+    }
+)

--- a/src/crate/theme/rtd/conf/dbal.py
+++ b/src/crate/theme/rtd/conf/dbal.py
@@ -19,17 +19,23 @@
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
 
+
 from crate.theme.rtd.conf import *
 
-project = u'CrateDB DBAL'
+# If you update the `project` value here, you must update it in the
+# `src/crate/theme/rtd/crate/sidebartoc.html` file or else Sphinx will not
+# expand the sidebar TOC for this project.
+project = u"CrateDB DBAL"
 html_title = project
 
-url_path = 'docs/dbal'
+url_path = "docs/dbal"
 
 # For sitemap extension
-html_baseurl = 'https://crate.io/%s/' % url_path
+html_baseurl = "https://crate.io/%s/" % url_path
 
 # For rel="canonical" links
-html_theme_options.update({
-    'canonical_url_path': '%s/en/latest/' % url_path,
-})
+html_theme_options.update(
+    {
+        "canonical_url_path": "%s/en/latest/" % url_path,
+    }
+)

--- a/src/crate/theme/rtd/conf/fake.py
+++ b/src/crate/theme/rtd/conf/fake.py
@@ -19,18 +19,23 @@
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
 
+
 from crate.theme.rtd.conf import *
 
-project = u'CrateDB Fake Docs'
+# You can change the `project` value to anything you want because
+# `src/crate/theme/rtd/crate/sidebartoc.html` does not have a menu item for
+# this project.
+project = u"CrateDB Fake Docs"
 html_title = project
 
-url_path = 'docs/fake'
+url_path = "docs/fake"
 
 # For sitemap extension
-html_baseurl = 'https://crate.io/%s/' % url_path
+html_baseurl = "https://crate.io/%s/" % url_path
 
 # For rel="canonical" links
-html_theme_options.update({
-    'canonical_url_path': '%s/en/latest/' % url_path,
-})
-
+html_theme_options.update(
+    {
+        "canonical_url_path": "%s/en/latest/" % url_path,
+    }
+)

--- a/src/crate/theme/rtd/conf/jdbc.py
+++ b/src/crate/theme/rtd/conf/jdbc.py
@@ -19,17 +19,23 @@
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
 
+
 from crate.theme.rtd.conf import *
 
-project = u'CrateDB JDBC'
+# If you update the `project` value here, you must update it in the
+# `src/crate/theme/rtd/crate/sidebartoc.html` file or else Sphinx will not
+# expand the sidebar TOC for this project.
+project = u"CrateDB JDBC"
 html_title = project
 
-url_path = 'docs/jdbc'
+url_path = "docs/jdbc"
 
 # For sitemap extension
-html_baseurl = 'https://crate.io/%s/' % url_path
+html_baseurl = "https://crate.io/%s/" % url_path
 
 # For rel="canonical" links
-html_theme_options.update({
-    'canonical_url_path': '%s/en/latest/' % url_path,
-})
+html_theme_options.update(
+    {
+        "canonical_url_path": "%s/en/latest/" % url_path,
+    }
+)

--- a/src/crate/theme/rtd/conf/npgsql.py
+++ b/src/crate/theme/rtd/conf/npgsql.py
@@ -19,17 +19,23 @@
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
 
+
 from crate.theme.rtd.conf import *
 
-project = u'CrateDB Npgsql'
+# If you update the `project` value here, you must update it in the
+# `src/crate/theme/rtd/crate/sidebartoc.html` file or else Sphinx will not
+# expand the sidebar TOC for this project.
+project = u"CrateDB Npgsql"
 html_title = project
 
-url_path = 'docs/npgsql'
+url_path = "docs/npgsql"
 
 # For sitemap extension
-html_baseurl = 'https://crate.io/%s/' % url_path
+html_baseurl = "https://crate.io/%s/" % url_path
 
 # For rel="canonical" links
-html_theme_options.update({
-    'canonical_url_path': '%s/en/latest/' % url_path,
-})
+html_theme_options.update(
+    {
+        "canonical_url_path": "%s/en/latest/" % url_path,
+    }
+)

--- a/src/crate/theme/rtd/conf/pdo.py
+++ b/src/crate/theme/rtd/conf/pdo.py
@@ -19,17 +19,23 @@
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
 
+
 from crate.theme.rtd.conf import *
 
-project = u'CrateDB PDO'
+# If you update the `project` value here, you must update it in the
+# `src/crate/theme/rtd/crate/sidebartoc.html` file or else Sphinx will not
+# expand the sidebar TOC for this project.
+project = u"CrateDB PDO"
 html_title = project
 
-url_path = 'docs/pdo'
+url_path = "docs/pdo"
 
 # For sitemap extension
-html_baseurl = 'https://crate.io/%s/' % url_path
+html_baseurl = "https://crate.io/%s/" % url_path
 
 # For rel="canonical" links
-html_theme_options.update({
-    'canonical_url_path': '%s/en/latest/' % url_path,
-})
+html_theme_options.update(
+    {
+        "canonical_url_path": "%s/en/latest/" % url_path,
+    }
+)

--- a/src/crate/theme/rtd/conf/python.py
+++ b/src/crate/theme/rtd/conf/python.py
@@ -19,17 +19,23 @@
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
 
+
 from crate.theme.rtd.conf import *
 
-project = u'CrateDB Python'
+# If you update the `project` value here, you must update it in the
+# `src/crate/theme/rtd/crate/sidebartoc.html` file or else Sphinx will not
+# expand the sidebar TOC for this project.
+project = u"CrateDB Python"
 html_title = project
 
-url_path = 'docs/python'
+url_path = "docs/python"
 
 # For sitemap extension
-html_baseurl = 'https://crate.io/%s/' % url_path
+html_baseurl = "https://crate.io/%s/" % url_path
 
 # For rel="canonical" links
-html_theme_options.update({
-    'canonical_url_path': '%s/en/latest/' % url_path,
-})
+html_theme_options.update(
+    {
+        "canonical_url_path": "%s/en/latest/" % url_path,
+    }
+)

--- a/src/crate/theme/rtd/conf/sql_99.py
+++ b/src/crate/theme/rtd/conf/sql_99.py
@@ -19,17 +19,23 @@
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
 
+
 from crate.theme.rtd.conf import *
 
-project = u'SQL 99'
+# If you update the `project` value here, you must update it in the
+# `src/crate/theme/rtd/crate/sidebartoc.html` file or else Sphinx will not
+# expand the sidebar TOC for this project.
+project = u"SQL 99"
 html_title = project
 
-url_path = 'docs/sql-99'
+url_path = "docs/sql-99"
 
 # For sitemap extension
-html_baseurl = 'https://crate.io/%s/' % url_path
+html_baseurl = "https://crate.io/%s/" % url_path
 
 # For rel="canonical" links
-html_theme_options.update({
-    'canonical_url_path': '%s/en/latest/' % url_path,
-})
+html_theme_options.update(
+    {
+        "canonical_url_path": "%s/en/latest/" % url_path,
+    }
+)

--- a/src/crate/theme/rtd/crate/sidebartoc.html
+++ b/src/crate/theme/rtd/crate/sidebartoc.html
@@ -9,7 +9,7 @@
     {% else %}
       <li class="navleft-item"><a href="/docs/crate/tutorials/">Tutorials</a></li>
     {% endif %}
-    {% if project == 'CrateDB: How-To Guides' %}
+    {% if project == 'CrateDB: How-Tos' %}
       <li class="current">
         <a class="current-active" href="{{ pathto(master_doc) }}">How-To Guides</a>
         {{ toctree(maxdepth=3|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
@@ -62,7 +62,7 @@
     {% else %}
       <li class="navleft-item"><a href="/docs/cloud/tutorials/">Tutorials</a></li>
     {% endif %}
-    {% if project == 'CrateDB Cloud: How-To Guides' %}
+    {% if project == 'CrateDB Cloud: How-Tos' %}
       <li class="current">
         <a class="current-active" href="{{ pathto(master_doc) }}">How-To Guides</a>
         {{ toctree(maxdepth=1|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}


### PR DESCRIPTION
Specifically:

- The `project` variable for both how-to projects was updated in the Python
  config files but not the template. This change corrects that issue and adds a
  helpful comment above all `project` variable assignments to help avoid this
  issue in the future.

- Reformatted all Python files using Black <https://pypi.org/project/black/>.
  This was an easy change while I was digging into the Python code.

- Shortened `CHANGES.rst` title to match our current style guide.