### PR TITLE
Fix the build by bumping to crate-docs 1.0.0

### DIFF
--- a/docs/build.json
+++ b/docs/build.json
@@ -1,5 +1,5 @@
 {
   "schemaVersion": 1,
   "label": "docs build",
-  "message": "0.4.0"
+  "message": "1.0.0"
 }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -125,5 +125,5 @@ Fifth-level heading
 This is the deepest heading level we support.
 
 
-.. _developer guide: https://github.com/crate/crate-docs-theme/blob/master/DEVELOP.rst#make-changes
+.. _developer guide: https://github.com/crate/crate-docs-theme/blob/master/DEVELOP.rst#user-content-make-changes
 .. _report an issue: https://github.com/crate/crate-docs/issues/new


### PR DESCRIPTION
Hi there,

this patch fixes https://github.com/crate/crate-docs/issues/65 reported by @msbt. You can either choose this one, or bring in #245 instead. Or do both, one after the other.

With kind regards,
Andreas.