### PR TITLE
Permit installation on Sphinx 4

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Unreleased
 
 - Minor CSS fixup for glossary link
 - Upgrade to crate-docs 2.0.0
+- Permit installation on Sphinx 4
 
 
 2021/03/18 0.14.0

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        "Sphinx>=1.8.5,<4",
+        "Sphinx>=1.8.5,<5",
         "sphinxcontrib-plantuml==0.19",
         "sphinx_sitemap==2.2.0",
     ],


### PR DESCRIPTION
Hi,

Sphinx 4.0.0b1 was released yesterday and I wanted to take the chance to check whether our infrastructure will work on that without further ado. In order to make it installable, we will have to relax the constraints here.

As far as I can see, things are working without any issues. However, we will carefully check the state of the onion as soon as this trickles downstream.

Bumping this will also probably don't do any immediate harm, because, unless explicitly pinned on the dependency chain, RTD will still just use Sphinx 1.8. So, this patch should come without any risks.

With kind regards,
Andreas.
