### PR TITLE
Add intersphinx mapping

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ Unreleased
 - Minor CSS fixup for glossary link
 - Upgrade to crate-docs 2.0.0
 - Permit installation on Sphinx 4
+- Add intersphinx mapping for cross referencing documentation across different
+  repositories
 
 
 2021/03/18 0.14.0

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -117,6 +117,7 @@ Fourth-level heading
     subpage
 
     glossary
+    links
 
 This paragraph contains a link to the :ref:`foo <gloss-foo>` glossary entry
 that should be styled black with a dotted underline to make it less prominent

--- a/docs/links.rst
+++ b/docs/links.rst
@@ -1,0 +1,46 @@
+=============================
+Linking to other repositories
+=============================
+
+
+CrateDB core
+============
+
+- :ref:`crate-reference:index`
+- :ref:`crate-tutorials:index`
+- :ref:`crate-howtos:index`
+
+
+CrateDB clients
+===============
+
+- :ref:`crate-admin-ui:index`
+- :ref:`crate-crash:index`
+- :ref:`crate-clients-tools:index`
+- :ref:`crate-jdbc:index`
+- :ref:`crate-npgsql:index`
+- :ref:`crate-dbal:index`
+- :ref:`crate-pdo:index`
+- :ref:`crate-python:index`
+
+
+CrateDB Cloud
+=============
+
+- :ref:`cloud-reference:index`
+- :ref:`cloud-tutorials:index`
+- :ref:`cloud-howtos:index`
+- :ref:`cloud-cli:index`
+
+
+Misc
+====
+
+- :ref:`sql-99:index`
+
+
+CrateDB Docs
+============
+
+- :ref:`crate-docs:index`
+- :ref:`crate-docs-theme:index`

--- a/src/crate/theme/rtd/conf/__init__.py
+++ b/src/crate/theme/rtd/conf/__init__.py
@@ -29,7 +29,10 @@ master_doc = "index"
 exclude_patterns = [".*", "*.lint", "README.rst", "requirements.txt"]
 exclude_trees = ["pyenv", "tmp", "out", "parts", "clients", "eggs"]
 
-extensions = ["sphinx_sitemap"]
+extensions = [
+    "sphinx_sitemap",
+    "sphinx.ext.intersphinx",
+]
 
 # Configure the theme
 html_theme = "crate"
@@ -61,6 +64,38 @@ sitemap_filename = "site.xml"
 language = "en"
 version = "latest"
 sitemap_url_scheme = "{lang}{version}{link}"
+
+# Configure intersphinx mapping
+intersphinx_mapping = {
+
+    # CrateDB core
+    'crate-reference': ('https://crate.io/docs/crate/reference/en/latest/', None),
+    'crate-tutorials': ('https://crate.io/docs/crate/tutorials/en/latest/', None),
+    'crate-howtos': ('https://crate.io/docs/crate/howtos/en/latest/', None),
+
+    # CrateDB clients
+    'crate-admin-ui': ('https://crate.io/docs/crate/admin-ui/en/latest/', None),
+    'crate-crash': ('https://crate.io/docs/crate/crash/en/latest/', None),
+    'crate-clients-tools': ('https://crate.io/docs/crate/clients-tools/en/latest/', None),
+    'crate-jdbc': ('https://crate.io/docs/clients/jdbc/en/latest/', None),
+    'crate-npgsql': ('https://crate.io/docs/clients/npgsql/en/latest/', None),
+    'crate-dbal': ('https://crate.io/docs/clients/dbal/en/latest/', None),
+    'crate-pdo': ('https://crate.io/docs/clients/pdo/en/latest/', None),
+    'crate-python': ('https://crate.io/docs/clients/python/en/latest/', None),
+
+    # CrateDB Cloud
+    'cloud-reference': ('https://crate.io/docs/cloud/reference/en/latest/', None),
+    'cloud-tutorials': ('https://crate.io/docs/cloud/tutorials/en/latest/', None),
+    'cloud-howtos': ('https://crate.io/docs/cloud/howtos/en/latest/', None),
+    'cloud-cli': ('https://crate.io/docs/cloud/cli/en/latest/', None),
+
+    # Misc
+    'sql-99': ('https://crate.io/docs/sql-99/en/latest/', None),
+
+    # CrateDB Docs
+    'crate-docs': ('https://crate-docs.readthedocs.io/en/latest/', None),
+    'crate-docs-theme': ('https://crate-docs-theme.readthedocs.io/en/latest/', None),
+}
 
 
 def setup(app):


### PR DESCRIPTION
Hi,

this patch brings the intersphinx mapping from https://github.com/crate/crate-tutorials/pull/47 to where it should actually happen. When adding it here, all references will be available to all downstream repositories without further ado.

With kind regards,
Andreas.
