### PR TITLE
add ESI promo header and newsletter footer

### DIFF
--- a/src/crate/theme/rtd/crate/footer.html
+++ b/src/crate/theme/rtd/crate/footer.html
@@ -14,7 +14,7 @@
               <li class="footer-listitem-new"><a href="https://crate.io/download/">Get CrateDB</a></li>
             </ul>
           </div>
-          
+
           <div class="w-col w-col-2 footer-menu">
             <p class="menu-Label">Use Cases</p>
             <ul class="vertical-menu">
@@ -26,7 +26,7 @@
               <li class="footer-listitem-new"><a href="https://crate.io/use-cases/cyber-security/">Cybersecurity</a></li>
             </ul>
           </div>
-          
+
           <div class="w-col w-col-2 footer-menu">
             <p class="menu-Label">Resources</p>
             <ul class="vertical-menu">
@@ -85,3 +85,7 @@
     </div>
   </div>
 </footer>
+
+<!--esi
+<esi:include src="https://crate.io/navi-newsletter.php" />
+-->

--- a/src/crate/theme/rtd/crate/navbar.html
+++ b/src/crate/theme/rtd/crate/navbar.html
@@ -1,3 +1,7 @@
+<!--esi
+<esi:include src="https://crate.io/navi-promo.php" />
+-->
+
 <input type="checkbox" id="mobile-nav-new">
 
 <header class="header-nav">


### PR DESCRIPTION
for navi-newsletter.php and navi-promo.php to dynamically include a promotion header and a newsletter after the footer

## Summary of the changes / Why this is an improvement
with this we can include a dynamic promo header and the newsletter registration in the footer from WordPress

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
