### PR TITLE
Restructure sample content

### DIFF
--- a/docs/admonitions.rst
+++ b/docs/admonitions.rst
@@ -2,9 +2,15 @@
 Different kinds of admonitions
 ==============================
 
+Introduction
+============
+
 Admonitions are visually set off from the rest of the content and have a
 colored background. To the left of admonition content paragraphs, there is an
 icon that represents the kind/type of the admonition.
+
+Samples
+=======
 
 .. _first-admonition:
 
@@ -21,3 +27,21 @@ icon that represents the kind/type of the admonition.
     This is the first paragraph of a *tip* admonition.
 
     This is a second paragraph.
+
+.. _more-admonitions:
+
+.. SEEALSO::
+
+    This is the first paragraph of a *seealso* admonition.
+
+.. CAUTION::
+
+    This is the first paragraph of a *caution* admonition.
+
+.. WARNING::
+
+    This is the first paragraph of a *warning* admonition.
+
+.. DANGER::
+
+    This is the first paragraph of a *danger* admonition.

--- a/docs/admonitions.rst
+++ b/docs/admonitions.rst
@@ -1,0 +1,23 @@
+==============================
+Different kinds of admonitions
+==============================
+
+Admonitions are visually set off from the rest of the content and have a
+colored background. To the left of admonition content paragraphs, there is an
+icon that represents the kind/type of the admonition.
+
+.. _first-admonition:
+
+.. NOTE::
+
+    This is the first paragraph of a *note* admonition.
+
+    This is a second paragraph.
+
+.. _second-admonition:
+
+.. TIP::
+
+    This is the first paragraph of a *tip* admonition.
+
+    This is a second paragraph.

--- a/docs/headings.rst
+++ b/docs/headings.rst
@@ -1,0 +1,42 @@
+======================
+All levels of headings
+======================
+
+.. _top-level-heading:
+
+Top-level heading
+=================
+
+This is a paragraph within the 1st-level heading.
+
+
+.. _second-level-heading:
+
+Second-level heading
+--------------------
+
+This is a paragraph within a 2nd-level heading.
+
+
+.. _third-level-heading:
+
+Third-level heading
+~~~~~~~~~~~~~~~~~~~
+
+This is a paragraph within a 3rd-level heading.
+
+
+.. _fourth-level-heading:
+
+Fourth-level heading
+^^^^^^^^^^^^^^^^^^^^
+
+This is a paragraph within a 4th-level heading.
+
+
+.. _fifth-level-heading:
+
+Fifth-level heading
+...................
+
+This is the deepest heading level we support.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,99 +37,16 @@ How to improve this documentation:
    :local:
 
 
-.. _top-level-heading:
-
-Top-level heading
-=================
-
-.. _first-admonition:
-
-.. NOTE::
-
-    This is the first paragraph of a note admonition. The admonition is
-    visually set off from the rest of the content and has a colored background.
-
-    This is a second paragraph. To the left of both paragraphs, there is an
-    icon that represents the concept of a "note".
-
-
-.. _second-level-heading:
-
-Second-level heading
---------------------
-
-.. _closed-list:
-
-This is a closed list:
-
-* It has bullet points like this one
-* The list items are spaced close together like subsequent lines in a paragraph
-* Typically the items are short and are not terminated with a period
-
-.. _open-list:
-
-An open list is quite different:
-
-.. rst-class:: open
-
-* Notice how this sentence is terminated with a period.
-
-  And there's a second paragraph too.
-
-* This is the second item. Notice how it is separated from the first item like
-  a regular paragraph would be.
-
-This is a regular paragraph and not a list item.
-
-
-.. _third-level-heading:
-
-Third-level heading
-~~~~~~~~~~~~~~~~~~~
-
-.. NOTE::
-
-    Here's a regular list:
-
-    - This is the first list item
-    - The list items are spaced close together like subsequent lines in a
-      paragraph
-    - This list is styled the same as the :ref:`closed list <closed-list>`
-      above
-
-    This is an open list:
-
-     .. rst-class:: open
-
-     - This list looks the same as the :ref:`open list <closed-list>` above
-
-     - The list items are separated as if they were separate paragraphs
-
-
-.. _fourth-level-heading:
-
-Fourth-level heading
-^^^^^^^^^^^^^^^^^^^^
-
 .. toctree::
     :maxdepth: 1
 
-    subpage
-
-    glossary
+    headings
+    admonitions
+    lists
     links
 
-This paragraph contains a link to the :ref:`foo <gloss-foo>` glossary entry
-that should be styled black with a dotted underline to make it less prominent
-and distinguish it from normal internal links.
-
-
-.. _fifth-level-heading:
-
-Fifth-level heading
-...................
-
-This is the deepest heading level we support.
+    subpage
+    glossary
 
 
 .. _developer guide: https://github.com/crate/crate-docs-theme/blob/master/DEVELOP.rst#user-content-making-changes-to-the-theme

--- a/docs/links.rst
+++ b/docs/links.rst
@@ -1,10 +1,21 @@
-=============================
-Linking to other repositories
-=============================
+========================
+Different kinds of links
+========================
 
+Glossary links
+==============
+
+This paragraph contains a link to the :ref:`foo <gloss-foo>` glossary entry
+that should be styled black with a dotted underline to make it less prominent
+and distinguish it from normal internal links.
+
+Intersphinx links
+=================
+
+Those links reference documentation sections within other repositories.
 
 CrateDB core
-============
+------------
 
 - :ref:`crate-reference:index`
 - :ref:`crate-tutorials:index`
@@ -12,7 +23,7 @@ CrateDB core
 
 
 CrateDB clients
-===============
+---------------
 
 - :ref:`crate-admin-ui:index`
 - :ref:`crate-crash:index`
@@ -25,7 +36,7 @@ CrateDB clients
 
 
 CrateDB Cloud
-=============
+-------------
 
 - :ref:`cloud-reference:index`
 - :ref:`cloud-tutorials:index`
@@ -34,13 +45,13 @@ CrateDB Cloud
 
 
 Misc
-====
+----
 
 - :ref:`sql-99:index`
 
 
 CrateDB Docs
-============
+------------
 
 - :ref:`crate-docs:index`
 - :ref:`crate-docs-theme:index`

--- a/docs/lists.rst
+++ b/docs/lists.rst
@@ -1,0 +1,54 @@
+========================
+Different kinds of lists
+========================
+
+Basics
+======
+
+.. _closed-list:
+
+This is a closed list:
+
+* It has bullet points like this one
+* The list items are spaced close together like subsequent lines in a paragraph
+* Typically the items are short and are not terminated with a period
+
+.. _open-list:
+
+An open list is quite different:
+
+.. rst-class:: open
+
+* Notice how this sentence is terminated with a period.
+
+  And there's a second paragraph too.
+
+* This is the second item. Notice how it is separated from the first item like
+  a regular paragraph would be.
+
+This is a regular paragraph and not a list item.
+
+
+With admonition
+===============
+
+These are lists within admonitions.
+
+.. NOTE::
+
+    Here's a regular list:
+
+    - This is the first list item
+    - The list items are spaced close together like subsequent lines in a
+      paragraph
+    - This list is styled the same as the :ref:`closed list <closed-list>`
+      above
+
+    This is an open list:
+
+     .. rst-class:: open
+
+     - This list looks the same as the :ref:`open list <closed-list>` above
+
+     - The list items are separated as if they were separate paragraphs
+

--- a/docs/subpage.rst
+++ b/docs/subpage.rst
@@ -1,6 +1,6 @@
-============
-Test subpage
-============
+=========
+A subpage
+=========
 
 This is a subpage.
 


### PR DESCRIPTION
Hi there,

in order to reduce confusion, this patch restructures the sample content that can be used for visually testing the theme. The idea is that each "topic/feature" has a dedicated page.

With kind regards,
Andreas.