### PR TITLE
Add PlantUML sample

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,6 +24,14 @@ jobs:
         with:
           python-version: 3.7
 
+      - name: Install PlantUML on Linux
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get install plantuml
+
+      - name: Install PlantUML on macOS
+        if: matrix.os == 'macos-latest'
+        run: brew install plantuml
+
       - name: Build docs
         run: |
           cd docs && make check

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Unreleased
 - Fix the docs title for Segment.io / GA tracking
 - Add ESI snippets for a dynamic promotion header and newsletter footer
 - Improve margins and rename section class to ``w-canvas`` for proper tagging
+- Add extension "sphinxcontrib.plantuml"
 
 
 2021/03/18 0.14.0

--- a/README.rst
+++ b/README.rst
@@ -15,6 +15,16 @@ For help making changes to the theme, see the `developer docs`_.
 Using the theme
 ===============
 
+Prerequisites
+-------------
+
+The documentation can include UML diagrams which will be rendered using
+`sphinxcontrib-plantuml`_. In order to satisfy its requirements, run::
+
+    brew install plantuml
+
+.. _sphinxcontrib-plantuml: https://pypi.org/project/sphinxcontrib-plantuml/
+
 Installation
 ------------
 
@@ -26,8 +36,8 @@ it automatically.
 Configuration
 -------------
 
-The Crate documentation is composed of multiple separate documentation
-projects, seemlessly interlinked via the Crate docs theme.
+The Crate.io documentation is composed of multiple separate documentation
+projects, seamlessly interlinked via the Crate docs theme.
 
 To use the theme, add this line to your Sphinx ``conf.py`` file::
 

--- a/docs/diagrams.rst
+++ b/docs/diagrams.rst
@@ -1,0 +1,11 @@
+===========================
+Different kinds of diagrams
+===========================
+
+PlantUML
+========
+
+.. uml::
+
+    Alice -> Bob: Hi!
+    Alice <- Bob: How are you?

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,6 +45,7 @@ How to improve this documentation:
     lists
     links
     images
+    diagrams
 
     subpage
     glossary

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     zip_safe=False,
     install_requires=[
         "Sphinx>=1.8.5,<5",
-        "sphinxcontrib-plantuml==0.19",
+        "sphinxcontrib-plantuml==0.21",
         "sphinx_sitemap==2.2.0",
     ],
     python_requires=">=3.7",

--- a/src/crate/theme/rtd/conf/__init__.py
+++ b/src/crate/theme/rtd/conf/__init__.py
@@ -32,6 +32,7 @@ exclude_trees = ["pyenv", "tmp", "out", "parts", "clients", "eggs"]
 extensions = [
     "sphinx_sitemap",
     "sphinx.ext.intersphinx",
+    "sphinxcontrib.plantuml",
 ]
 
 # Configure the theme


### PR DESCRIPTION
Hi there,

this patch completes the documentation rig with a sample of an UML diagram in order to verify the PlantUML Sphinx addon.

With kind regards,
Andreas.
