### PR TITLE
Add extension "sphinxext.opengraph"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ Unreleased
 - Add ESI snippets for a dynamic promotion header and newsletter footer
 - Improve margins and rename section class to ``w-canvas`` for proper tagging
 - Add extension "sphinxcontrib.plantuml"
+- Add extension "sphinxext.opengraph"
 
 
 2021/03/18 0.14.0

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
         "Sphinx>=1.8.5,<5",
         "sphinxcontrib-plantuml==0.21",
         "sphinx_sitemap==2.2.0",
+        "sphinxext.opengraph==0.4.1",
     ],
     python_requires=">=3.7",
 )

--- a/src/crate/theme/rtd/conf/__init__.py
+++ b/src/crate/theme/rtd/conf/__init__.py
@@ -33,6 +33,7 @@ extensions = [
     "sphinx_sitemap",
     "sphinx.ext.intersphinx",
     "sphinxcontrib.plantuml",
+    "sphinxext.opengraph",
 ]
 
 # Configure the theme
@@ -97,6 +98,15 @@ intersphinx_mapping = {
     'crate-docs': ('https://crate-docs.readthedocs.io/en/latest/', None),
     'crate-docs-theme': ('https://crate-docs-theme.readthedocs.io/en/latest/', None),
 }
+
+# Configure OpenGraph extension
+ogp_site_url = "https://crate.io/"
+ogp_description_length = 300
+ogp_site_name = "CrateDB documentation"
+ogp_image = "https://user-images.githubusercontent.com/453543/119536319-3c9ca480-bd89-11eb-908d-3da78e55f17b.png"
+ogp_image_alt = False
+ogp_use_first_image = True
+ogp_type = "website"
 
 
 def setup(app):


### PR DESCRIPTION
Hi there,

this patch adds and activates the Sphinx extension [sphinxext-opengraph](https://github.com/wpilibsuite/sphinxext-opengraph) to generate OpenGraph metadata (https://ogp.me/).

```html
  <meta property="og:title" content="Different kinds of diagrams" />
  <meta property="og:type" content="website" />
  <meta property="og:url" content="https://crate.io/diagrams.html" />
  <meta property="og:site_name" content="Crate.io documentation" />
  <meta property="og:description" content="PlantUML:" />
  <meta property="og:image" content="https://user-images.githubusercontent.com/453543/119536319-3c9ca480-bd89-11eb-908d-3da78e55f17b.png" />
```

With kind regards,
Andreas.
