### PR TITLE
Add "sphinx-copybutton" extension

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Unreleased
 - Improve margins and rename section class to ``w-canvas`` for proper tagging
 - Add extension "sphinxcontrib.plantuml"
 - Add extension "sphinxext.opengraph"
+- Add "sphinx-copybutton" extension
 
 
 2021/03/18 0.14.0

--- a/docs/codesnippets.rst
+++ b/docs/codesnippets.rst
@@ -1,0 +1,77 @@
+=====================
+Code snippet examples
+=====================
+
+
+SQL
+===
+
+.. highlight:: psql
+
+Plain
+-----
+
+::
+
+    ALTER TABLE foo ADD COLUMN new_column INTEGER;
+
+With prompts
+------------
+
+::
+
+    mysql> CREATE TABLE foo (
+    ...       id integer primary key,
+    ...       name varchar(255),
+    ...       date datetime,
+    ...       fruits set('apple', 'pear', 'banana')
+    ...    ) CHARACTER SET utf8 COLLATE utf8_unicode_ci;
+
+::
+
+    cr> COPY foo_imported FROM '/tmp/dump.csv' WITH (bulk_size=1000);
+
+With prompts and doctests
+-------------------------
+
+::
+
+    cr> CREATE TABLE metrics1 (
+    ...     weight REAL CONSTRAINT weight_is_positive CHECK (weight >= 0),
+    ... );
+    CREATE OK, 1 row affected  (... sec)
+
+::
+
+    cr> drop table metrics1;
+    DROP OK, 1 row affected (... sec)
+
+::
+
+    cr> select array(select height from sys.summits order by height desc limit 5)
+    ... as top5_mountains_array;
+    +--------------------------------+
+    | top5_mountains_array           |
+    +--------------------------------+
+    | [4808, 4634, 4545, 4527, 4506] |
+    +--------------------------------+
+    SELECT 1 row in set (... sec)
+
+
+Configuration files
+===================
+
+.. code-block:: ini
+
+    [client]
+    default-character-set=utf8
+    [mysqld]
+    character-set-server=utf8
+
+
+Terminal commands
+=================
+
+.. code-block:: sh
+
+    sh$ csvsql --db crate://localhost:4200 --insert /tmp/dump.csv

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -46,6 +46,7 @@ How to improve this documentation:
     links
     images
     diagrams
+    codesnippets
 
     subpage
     glossary

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
         "sphinxcontrib-plantuml==0.21",
         "sphinx_sitemap==2.2.0",
         "sphinxext.opengraph==0.4.1",
+        "sphinx-copybutton==0.3.1",
     ],
     python_requires=">=3.7",
 )

--- a/src/crate/theme/rtd/conf/__init__.py
+++ b/src/crate/theme/rtd/conf/__init__.py
@@ -34,6 +34,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinxcontrib.plantuml",
     "sphinxext.opengraph",
+    "sphinx_copybutton",
 ]
 
 # Configure the theme
@@ -108,6 +109,10 @@ ogp_image_alt = False
 ogp_use_first_image = True
 ogp_type = "website"
 
+# Configure Sphinx-copybutton
+copybutton_remove_prompts = True
+copybutton_prompt_text = r">>> |\.\.\. |\$ |sh\$ |cr> |mysql> |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
+copybutton_prompt_is_regexp = True
 
 def setup(app):
     # Force the canonical URL in multiple ways

--- a/src/crate/theme/rtd/crate/layout.html
+++ b/src/crate/theme/rtd/crate/layout.html
@@ -1,12 +1,6 @@
 {% extends "base.html" %}
 
-  {% set css_files = [
-    ]
-  %}
-
-  {% set script_files = [
-    '_static/underscore.js',
-    '_static/doctools.js',
+  {% set extra_script_files = [
     '_static/language_data.js',
     '_static/searchtools.js',
     ]

--- a/src/crate/theme/rtd/crate/static/css/custom.css
+++ b/src/crate/theme/rtd/crate/static/css/custom.css
@@ -8,6 +8,12 @@
   margin-bottom: 64px;
 }
 
+a.copybtn {
+  width: 2em;
+  height: 2em;
+  top: .5em;
+}
+
 /**
 * Bootstrap components (removed bootstrap)
 */


### PR DESCRIPTION
Hi there,

having a sound implementation for copying code snippets from the documentation as outlined within #258 is a longstanding wish. This patch uses the excellent [sphinx-copybutton](https://github.com/executablebooks/sphinx-copybutton) extension as suggested by @msbt. Thank you!

With kind regards,
Andreas.

/cc @proddata, @hammerhead, @seut 