### PR TITLE
Use Pygments style "material" for code highlighting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,7 @@ Unreleased
 - Add extension "sphinxcontrib.plantuml"
 - Add extension "sphinxext.opengraph"
 - Add "sphinx-copybutton" extension
+- Use Pygments style "material" for code highlighting
 
 
 2021/03/18 0.14.0

--- a/src/crate/theme/rtd/crate/static/css/crateio-rtd.css
+++ b/src/crate/theme/rtd/crate/static/css/crateio-rtd.css
@@ -21,7 +21,7 @@ a.current, a.current-active {
     margin: 1em 0px;
     border: 1px solid #ccc;
     border-radius: 2px;
-    background: #f0f0f0 none repeat scroll 0 0;
+    background: inherit none repeat scroll 0 0;
 }
 
 blockquote {

--- a/src/crate/theme/rtd/crate/static/css/custom.css
+++ b/src/crate/theme/rtd/crate/static/css/custom.css
@@ -12,6 +12,7 @@ a.copybtn {
   width: 2em;
   height: 2em;
   top: .5em;
+  opacity: .6;
 }
 
 /**

--- a/src/crate/theme/rtd/crate/theme.conf
+++ b/src/crate/theme/rtd/crate/theme.conf
@@ -1,6 +1,6 @@
 [theme]
 inherit = basic
-pygments_style = friendly
+pygments_style = material
 
 [options]
 # Navigation bar title. (Default: ``project`` value)


### PR DESCRIPTION
Hi there,

this is a first improvement in order to resolve #257. It brings in more contrast in order to improve the typeface to distinguish prose from code.

![image](https://user-images.githubusercontent.com/453543/119666039-47ad0e80-be35-11eb-9d5a-298835335102.png)

With kind regards,
Andreas.
