### PR TITLE
Add `doing_docs` config module (hidden menu item)

### DIFF
--- a/src/crate/theme/rtd/conf/doing_docs.py
+++ b/src/crate/theme/rtd/conf/doing_docs.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8; -*-
+#
+# Licensed to Crate (https://crate.io) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  Crate licenses
+# this file to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# However, if you have executed another commercial license agreement
+# with Crate these terms will supersede the license and you may use the
+# software solely pursuant to the terms of the relevant commercial agreement.
+
+
+from crate.theme.rtd.conf import *
+
+# If you update the `project` value here, you must update it in the
+# `src/crate/theme/rtd/crate/sidebartoc.html` file or else Sphinx will not
+# expand the sidebar TOC for this project.
+project = u"Doing Docs"
+html_title = project
+
+url_path = "docs/meta"
+
+# For sitemap extension
+html_baseurl = "https://crate.io/%s/" % url_path
+
+# For rel="canonical" links
+html_theme_options.update(
+    {
+        "canonical_url_path": "%s/en/latest/" % url_path,
+    }
+)

--- a/src/crate/theme/rtd/crate/sidebartoc.html
+++ b/src/crate/theme/rtd/crate/sidebartoc.html
@@ -138,5 +138,12 @@
   </li>
   {% endif %}
 
+  {% if project == 'Doing Docs' %}
+  <li class="current">
+    <a class="current-active" href="{{ pathto(master_doc) }}">Doing Docs at Crate.io</a>
+    {{ toctree(maxdepth=2|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
+  </li>
+  {% endif %}
+
   <li class="navleft-item"><a href="/support/">Support</a></li>
 </ul>


### PR DESCRIPTION
Add `doing_docs` config module (hidden menu item)

This config module will unlock a hidden "Doing Docs at Crate.io" heading in the left-hand navigation menu when the new "Doing Docs at Crate.io" project (currently a [WIP][1]) is accessed directly. This is similar to how a hidden [SQL-99 Complete, Really][2] heading is unlocked when you view that project directly.

The result will be:

- The docs menu is unaltered for all normal visitors, and there is no mention of a "Doing Docs at Crate.io" page.

- People who directly access the "Doing Docs at Crate.io" docs (e.g., via a link from the GitHub [crate-docs][3] project page) will see an additional navigation item titled "Doing Docs at Crate.io". This navigation item is helpful because it will expand to show the content tree, like all other top-level navigation items.

We could use the standard [Read The Docs theme][4]. However, the "Doing Docs at Crate.io" project is intended to be a reference implementation. For that reason, the Sphinx project should demonstrate the standard way of integrating with the crate-docs-theme.

This docs project is not user-facing, however. Thus, I have implemented this config module as a hidden menu item.

[1]: https://github.com/crate/crate-docs/pull/85
[2]: https://github.com/crate/sql-99
[3]: https://github.com/crate/crate-docs
[4]: https://sphinx-rtd-theme.readthedocs.io/en/stable/
