### PR TITLE
Adjust style of highlighted codeblocks: Border, border radius and shadow

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Unreleased
 ----------
 
 - Fix some client docs intersphinx URLs
+- Adjust style of highlighted codeblocks: Border, border radius and shadow
 
 
 2021/05/26 0.15.0

--- a/src/crate/theme/rtd/crate/static/css/crateio-rtd.css
+++ b/src/crate/theme/rtd/crate/static/css/crateio-rtd.css
@@ -14,13 +14,13 @@ a.current, a.current-active {
 
 .highlight {
     font-size: 14px;
+    border-radius: 5px;
+    box-shadow: 2px 5px 10px silver;
 }
 
 .highlight pre {
     padding: 15px;
     margin: 1em 0px;
-    border: 1px solid #ccc;
-    border-radius: 2px;
     background: inherit none repeat scroll 0 0;
 }
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

- Removed gray border from pre-element
- Added border-radius to highlight-element
- Added small box shadow to highlight-element

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed


## Result
![image](https://user-images.githubusercontent.com/23557193/119675922-baba8300-be3d-11eb-8210-53c2203f1bcd.png)
