### PR TITLE
Fix intersphinx project URLs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ CHANGES
 Unreleased
 ----------
 
+- Fix some client docs intersphinx URLs
+
 
 2021/05/26 0.15.0
 -----------------

--- a/src/crate/theme/rtd/conf/__init__.py
+++ b/src/crate/theme/rtd/conf/__init__.py
@@ -80,11 +80,11 @@ intersphinx_mapping = {
     'crate-admin-ui': ('https://crate.io/docs/crate/admin-ui/en/latest/', None),
     'crate-crash': ('https://crate.io/docs/crate/crash/en/latest/', None),
     'crate-clients-tools': ('https://crate.io/docs/crate/clients-tools/en/latest/', None),
-    'crate-jdbc': ('https://crate.io/docs/clients/jdbc/en/latest/', None),
-    'crate-npgsql': ('https://crate.io/docs/clients/npgsql/en/latest/', None),
-    'crate-dbal': ('https://crate.io/docs/clients/dbal/en/latest/', None),
-    'crate-pdo': ('https://crate.io/docs/clients/pdo/en/latest/', None),
-    'crate-python': ('https://crate.io/docs/clients/python/en/latest/', None),
+    'crate-jdbc': ('https://crate.io/docs/jdbc/en/latest/', None),
+    'crate-npgsql': ('https://crate.io/docs/npgsql/en/latest/', None),
+    'crate-dbal': ('https://crate.io/docs/dbal/en/latest/', None),
+    'crate-pdo': ('https://crate.io/docs/pdo/en/latest/', None),
+    'crate-python': ('https://crate.io/docs/python/en/latest/', None),
 
     # CrateDB Cloud
     'cloud-reference': ('https://crate.io/docs/cloud/reference/en/latest/', None),


### PR DESCRIPTION
Some of the clients docs used an outdated URL pattern containing `clients/`. I noticed this in the output from `make dev`, which alerts you to any redirects encountered. This commit corrects those URLs.
