### PR TITLE
Attempt to fix version dropdown by re-adding Bootstrap v4.5.3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Unreleased
 - Adjust style of highlighted codeblocks: Border, border radius and shadow
 - Improve OpenGraph `og:url` computation
 - Fix ``Uncaught TypeError: $.cookie is not a function``
+- Fix version dropdown by re-adding Bootstrap v4.5.3
 
 
 2021/05/26 0.15.0

--- a/package.json
+++ b/package.json
@@ -1,10 +1,12 @@
 {
   "devDependencies": {
+    "bootstrap": "4.5.3",
     "css-loader": "^5.2.1",
     "expose-loader": "^2.0.0",
     "jquery": "^3.6.0",
     "jquery.cookie": "^1.4.1",
     "normalize.css": "^8.0.1",
+    "popper.js": "^1.16.1",
     "sticky-sidebar": "^3.3.1",
     "style-loader": "^2.0.0",
     "webpack": "^5.31.2",

--- a/src/crate/theme/rtd/crate/static/js/index.js
+++ b/src/crate/theme/rtd/crate/static/js/index.js
@@ -1,6 +1,7 @@
 import "jquery";
 import "jquery.cookie";
 import "sticky-sidebar";
+import "bootstrap";
 
 import "./crate";
 import "./custom";

--- a/yarn.lock
+++ b/yarn.lock
@@ -240,6 +240,11 @@ big.js@^5.2.2:
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
   integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
 
+bootstrap@4.5.3:
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.5.3.tgz#c6a72b355aaf323920be800246a6e4ef30997fe6"
+  integrity sha512-o9ppKQioXGqhw8Z7mah6KdTYpNQY//tipnkxppWhPbiSWdD+1raYsnhwEZjkTHYbGee4cVQ0Rx65EhOY/HNLcQ==
+
 browserslist@^4.14.5:
   version "4.16.6"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.6.tgz#d7901277a5a88e554ed305b183ec9b0c08f66fa2"
@@ -838,6 +843,11 @@ pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+popper.js@^1.16.1:
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1.tgz#2a223cb3dc7b6213d740e40372be40de43e65b1b"
+  integrity sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==
 
 postcss-modules-extract-imports@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
This is an attempt to fix #281.