### PR TITLE
Improve sphinx-copybutton: Enable copying empty lines

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Unreleased
 ----------
 
 - Switch sphinx-copybutton cursor to pointer
+- Improve sphinx-copybutton: Enable copying empty lines
 
 
 2021/06/07 0.15.3

--- a/docs/codesnippets.rst
+++ b/docs/codesnippets.rst
@@ -75,3 +75,22 @@ Terminal commands
 .. code-block:: sh
 
     sh$ csvsql --db crate://localhost:4200 --insert /tmp/dump.csv
+
+
+Code blocks
+===========
+
+With prompts and empty lines
+----------------------------
+
+This snippet can be used to verify that ``sphinx-copybutton`` works
+appropriately by also honoring empty lines.
+
+.. code-block:: python
+
+    >>> from sqlalchemy.ext import declarative
+    >>> from crate.client.sqlalchemy import types
+    >>> from uuid import uuid4
+
+    >>> def gen_key():
+    ...     return str(uuid4())

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
         "sphinxcontrib-plantuml==0.21",
         "sphinx_sitemap==2.2.0",
         "sphinxext.opengraph==0.4.1",
-        "sphinx-copybutton==0.3.1",
+        "sphinx-copybutton>=0.3.1,<1",
     ],
     python_requires=">=3.7",
 )


### PR DESCRIPTION
### Problem
Currently, empty lines in code snippets will not get copied to the clipboard when using sphinx-copybutton. For example, see https://crate.io/docs/python/en/latest/sqlalchemy.html#tables.

### Solution
By following up on https://github.com/executablebooks/sphinx-copybutton/issues/84, this patch will resolve #287.

### Attention
For this to work, https://github.com/executablebooks/sphinx-copybutton/pull/127 will have to be integrated and released beforehand.
