### PR TITLE
Changed top and bottom margins for headings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Unreleased
 ----------
 
 - Improve sphinx-copybutton: Also handle ``PS>`` prompt for Powershell
+- Improve top and bottom margins for headings
 
 
 2021/05/27 0.15.1

--- a/src/crate/theme/rtd/crate/static/css/crateio.css
+++ b/src/crate/theme/rtd/crate/static/css/crateio.css
@@ -57,8 +57,8 @@ h1 {
 }
 
 h2 {
-  margin-top: 0px;
-  margin-bottom: 16px;
+  margin-top: 30px;
+  margin-bottom: 15px;
   font-size: 30px;
   line-height: 36px;
   font-weight: 700;
@@ -66,8 +66,8 @@ h2 {
 }
 
 h3 {
-  margin-top: 0px;
-  margin-bottom: 16px;
+  margin-top: 36px;
+  margin-bottom: 12px;
   color: #000;
   font-size: 24px;
   line-height: 30px;
@@ -76,8 +76,8 @@ h3 {
 }
 
 h4 {
-  margin-top: 0px;
-  margin-bottom: 16px;
+  margin-top: 30px;
+  margin-bottom: 10px;
   color: #b8b8b8;
   font-size: 20px;
   line-height: 26px;
@@ -85,8 +85,8 @@ h4 {
 }
 
 h5 {
-  margin-top: 0px;
-  margin-bottom: 16px;
+  margin-top: 24px;
+  margin-bottom: 8px;
   font-size: 16px;
   line-height: 24px;
   font-weight: 700;


### PR DESCRIPTION
- increase top margin to multiple of font-size
- bottom margin half of font-size

## Summary of the changes / Why this is an improvement


## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed

![image](https://user-images.githubusercontent.com/23557193/119965383-7d273880-bfaa-11eb-904b-a8d88e08b421.png)
![image](https://user-images.githubusercontent.com/23557193/119965479-9cbe6100-bfaa-11eb-9653-ff1423b32639.png)
