### PR TITLE
Improve version pinning

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,13 @@ CHANGES
 Unreleased
 ----------
 
-- added ``|striptags`` to the Segment titles for proper sanitizing
+
+2021/06/07 0.15.3
+-----------------
+
+- Add ``|striptags`` to the Segment titles for proper sanitizing
+- Improve version pinning
+
 
 2021/05/28 0.15.2
 -----------------

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,3 @@
 # Install the local crate-docs-theme package by specifying parent directory,
 # because `pip` is run from there.
 --editable=.
-sphinx==3.5.4
-docutils==0.16

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,8 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        "Sphinx>=1.8.5,<5",
+        "Sphinx>=3.5,<5",
+        "docutils==0.16",
         "sphinxcontrib-plantuml==0.21",
         "sphinx_sitemap==2.2.0",
         "sphinxext.opengraph==0.4.1",

--- a/src/crate/theme/rtd/conf/__init__.py
+++ b/src/crate/theme/rtd/conf/__init__.py
@@ -120,6 +120,7 @@ linkcheck_ignore = [
     "https://www.iso.org/obp/ui/.*"
 ]
 linkcheck_retries = 3
+linkcheck_timeout = 15
 
 def setup(app):
     # Force the canonical URL in multiple ways


### PR DESCRIPTION
Hi Naomi,

do you believe this would fit the bill for https://github.com/crate/crate-docs-theme/issues/294? Why we currently need `docutils==0.16` is outlined at #252.

With kind regards,
Andreas.