### PR TITLE
Switch copy button cursor to `pointer`

### DIFF
--- a/src/crate/theme/rtd/crate/static/css/custom.css
+++ b/src/crate/theme/rtd/crate/static/css/custom.css
@@ -13,6 +13,7 @@ a.copybtn {
   height: 2em;
   top: .5em;
   opacity: .6;
+  cursor: pointer;
 }
 
 /**


### PR DESCRIPTION
Previously, when you hovered over the copy button with your mouse, the cursor does not change from the default to indicate that you can click the element. This change makes the cursor switch to the `pointer` style (used to indicate that something is clickable).
