### PR TITLE
Improve the contrast of highlight comments and command output

### DIFF
--- a/src/crate/theme/rtd/crate/static/css/custom.css
+++ b/src/crate/theme/rtd/crate/static/css/custom.css
@@ -16,6 +16,11 @@ a.copybtn {
   cursor: pointer;
 }
 
+.highlight .c1,
+.highlight .go {
+    color: #B7C6CD;
+}
+
 /**
 * Bootstrap components (removed bootstrap)
 */


### PR DESCRIPTION
Within highlighted code examples, comments and command outputs are styled with a distinct color. Previously, the contrast between this color and the color of the background was relatively low. Low contrast makes text difficult to read and is an accessibility issue.

This commit increases the luminance of the color while preserving hue. This change improves the contrast and makes the text easier to read.

Color with the old CSS:

- Contrast ratio of 2.43:1
- Fails all WCAG accessibility guidelines
- See https://webaim.org/resources/contrastchecker/?fcolor=546E7A&bcolor=263238

New comment color:

- Contrast ratio of 7.5:1
- Passes all WCAG accessibility guidelines
- See https://webaim.org/resources/contrastchecker/?fcolor=B7C6CD&bcolor=263238
