### PR TITLE
Improve headings styles

### DIFF
--- a/src/crate/theme/rtd/crate/static/css/custom.css
+++ b/src/crate/theme/rtd/crate/static/css/custom.css
@@ -1418,7 +1418,57 @@ div.admonition ul.open p {
     padding: 0 0 10px 0;
 }
 
-h4 {
+
+/**
+ * Consistent and harmonious heading styles for all main text headers. The page
+ * title is visually distinct and so is not included here. We do not support
+ * headings below `<h6>`.
+ */
+
+
+h2, h3, h4, h5, h6 {
     color: #000;
     font-weight: bold;
+}
+
+h2 {
+    font-size: 30px;
+    line-height: 36px;    /*           this heading font-size * 1.2  */
+    margin-top: 30px;     /*           this heading font-size        */
+    margin-bottom: 15px;  /*           this heading font-size * 0.5  */
+}
+
+h3 {
+    font-size: 27px;      /* round(previous heading font-size * 0.9) */
+    line-height: 32px;    /* round(    this heading font-size * 1.2) */
+    margin-top: 27px;     /*           this heading font-size        */
+    margin-bottom: 14px;  /* round(    this heading font-size * 0.5) */
+}
+
+h4 {
+    font-size: 24px;      /* round(previous heading font-size * 0.9) */
+    line-height: 29px;    /* round(    this heading font-size * 1.2) */
+    margin-top: 24px;     /*           this heading font-size        */
+    margin-bottom: 12px;  /* round(    this heading font-size * 0.5) */
+}
+
+h5 {
+    font-size: 22px;      /* round(previous heading font-size * 0.9) */
+    line-height: 26px;    /* round(    this heading font-size * 1.2) */
+    margin-top: 22px;     /*           this heading font-size        */
+    margin-bottom: 11px;  /* round(    this heading font-size * 0.5) */
+}
+
+h5 {
+    font-size: 20px;      /* round(previous heading font-size * 0.9) */
+    line-height: 24px;    /* round(    this heading font-size * 1.2) */
+    margin-top: 20px;     /*           this heading font-size        */
+    margin-bottom: 10px;  /* round(    this heading font-size * 0.5) */
+}
+
+h6 {
+    font-size: 18px;      /* round(previous heading font-size * 0.9) */
+    line-height: 22px;    /* round(    this heading font-size * 1.2) */
+    margin-top: 18px;     /*           this heading font-size        */
+    margin-bottom: 9px;   /* round(    this heading font-size * 0.5) */
 }


### PR DESCRIPTION
The existing headings styles are a mismatch, likely due to people making small changes to specific headings over time without much coordination and with no refactoring.

This change refactors the headings styles for `<h2>` through `<h6>` (the only main text headers that we support).

The method I used was to take the largest heading and then scale that down by set percentages, one header at a time.

I have left the calculations used in the CSS file using comments so that future maintainers will:

1. Be able to get an understanding of why and how the headings are set up the way they are

2. Be able to make modifications and then propagate those changes through all headings (maintaining relative consistency)

