### PR TITLE
Don't make text bold with "align-left" and "align-right" directives

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,6 +43,7 @@ How to improve this documentation:
     headings
     admonitions
     lists
+    tables
     links
     images
     diagrams

--- a/docs/tables.rst
+++ b/docs/tables.rst
@@ -1,0 +1,34 @@
+=========================
+Different kinds of tables
+=========================
+
+A simple ``list-table`` with header.
+
+.. list-table::
+    :header-rows: 1
+
+    * - Foo
+      - Bar
+      - Baz
+      - Qux
+    * - ``KEEP``
+      - calm
+      - and
+      - carry on
+
+
+A ``list-table`` with header, column widths and alignment.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 15 10 30 20
+    :align: left
+
+    * - Foo
+      - Bar
+      - Baz
+      - Qux
+    * - ``KEEP``
+      - calm
+      - and
+      - carry on

--- a/src/crate/theme/rtd/crate/static/css/crateio.css
+++ b/src/crate/theme/rtd/crate/static/css/crateio.css
@@ -558,8 +558,11 @@ pre code {
   background-color: #e9fbff;
 }
 
+.align-left {
+  text-align: left !important;
+}
 .align-right {
-  text-align: right;
+  text-align: right !important;
 }
 
 .link-blue {
@@ -1161,10 +1164,6 @@ html.w-mod-js *[data-ix="hide-color-logo"] {
   display: none;
 }
 
-.align-left {
-  text-align: left !important;
-  font-weight: bold !important;
-}
   .pricing-table {
    width: 100%;
    margin-top: 35px;
@@ -1180,7 +1179,6 @@ html.w-mod-js *[data-ix="hide-color-logo"] {
 
 }
 .header-row td { background-color: #55d4f5 !important; }
-.align-left { padding-left: 12px !important; font-weight: bold; font-size: 15px !important; }
 
 .text-green {
   color: #44e3a6;


### PR DESCRIPTION
Hi there,

Sphinx' reStructuredText tables with an `:align: left` attribute appeared with bold text on [1]. This is not intended. See also https://github.com/crate/crate/pull/11631#pullrequestreview-739410569.

With kind regards,
Andreas.

[1] https://crate--11631.org.readthedocs.build/en/11631/general/ddl/data-types.html#supported-types