### PR TITLE
Use Node.js 14 LTS for building the distribution package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,11 +24,6 @@ jobs:
         with:
           python-version: 3.7
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v2
-        with:
-          node-version: '15'
-
       - name: Build package
         run: |
           make build

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ ACTIVATE := $(ENV_BIN)/activate
 PYTHON   := python3
 PIP      := $(ENV_BIN)/pip3
 TWINE    := $(ENV_BIN)/twine
+NODEENV  := $(ENV_BIN)/nodeenv
 DIST_DIR := .dist
 PYPIRC   := ~/.pypirc
 
@@ -66,10 +67,17 @@ build: $(TWINE)
 	. $(ACTIVATE) && \
 	    $(TWINE) check $(DIST_DIR)/*
 
+.PHONY: nodejs-lts
+nodejs-lts:
+	$(PIP) install nodeenv
+	$(NODEENV) --python-virtualenv --node=14.18.1
+
 .PHONY: bundle-assets
-bundle-assets:
-	yarn install
-	npx webpack --mode=production
+bundle-assets: nodejs-lts
+	. $(ACTIVATE) && \
+		printf "Node.js version: "; node --version && \
+		yarn install && \
+		npx webpack --mode=production
 
 .PHONY: upload
 upload: $(TWINE)


### PR DESCRIPTION
We had some troubles using Node.js 17, see #307. Using Node.js 14 LTS [1] does not break the build.

```shell
make build
# ...
.env/bin/nodeenv --python-virtualenv --node=14.18.1
 * Install prebuilt node (14.18.1) ..... done.
. .env/bin/activate && \
	printf "Node.js version: "; node --version && \
	yarn install && \
	npx webpack --mode=production
Node.js version: v14.18.1
yarn install v1.22.17
# ...
Checking .dist/crate_docs_theme-0.18.0-py3-none-any.whl: PASSED
Checking .dist/crate-docs-theme-0.18.0.tar.gz: PASSED
```

[1] Installed using [`nodeenv`](https://pypi.org/project/nodeenv/).
