### PR TITLE
Fix mergify configuration, `strict` mode became deprecated

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,14 +1,21 @@
 ---
+queue_rules:
+  - name: default
+    conditions:
+      - check-success~=Build docs
+      - check-success~=Build package
+      - check-success~=docs/readthedocs.org
+
 pull_request_rules:
-  - actions:
-      merge:
-        method: rebase
-        rebase_fallback: null
-        strict: true
+  - name: default
     conditions:
       - label=ready-to-merge
       - '#approved-reviews-by>=1'
       - status-success~=Build docs
       - status-success~=Build package
       - status-success~=docs/readthedocs.org
-    name: default
+    actions:
+      queue:
+        method: rebase
+        name: default
+        rebase_fallback: none


### PR DESCRIPTION
Hi,

this patch tries to follow https://github.com/crate/crate/pull/11952.

With kind regards,
Andreas.