### PR TITLE
Add links to top level docs toc entries

### DIFF
--- a/src/crate/theme/rtd/crate/sidebartoc.html
+++ b/src/crate/theme/rtd/crate/sidebartoc.html
@@ -1,5 +1,5 @@
 <ul class="toctree nav nav-list">
-  <li class="navleft-item">CrateDB</li>
+  <li class="navleft-item"><a href="/docs/crate/">CrateDB</a></li>
   <ul>
     {% if project == 'CrateDB: Tutorials' %}
       <li class="current">
@@ -52,7 +52,7 @@
     {% endif %}
   </ul>
 
-  <li class="navleft-item">CrateDB Cloud</li>
+  <li class="navleft-item"><a href="/docs/cloud/">CrateDB Cloud</a></li>
   <ul>
     {% if project == 'CrateDB Cloud: Tutorials' %}
       <li class="current">


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

They look similar to all other entries in table of contents and
should be therefore be clickable like all other entries

Note: Link-Target do not exist but are redirects forwarding to specific subpages. I think pointing to redirects is not wrong as target could be changes by changeing redirect
- https://crate.io/docs/crate/ => https://crate.io/docs/crate/tutorials/en/latest/
- https://crate.io/docs/cloud/ => https://crate.io/docs/cloud/tutorials/en/latest/

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
