### PR TITLE
additional search fix

### DIFF
--- a/src/crate/theme/rtd/crate/layout.html
+++ b/src/crate/theme/rtd/crate/layout.html
@@ -340,8 +340,10 @@
     }
   </script>
 
+  {% if pagename == "search" %}
   {% if theme_google_search_api_key %}
   <script type="text/javascript" src="{{ pathto('_static/js/search.js', 1) }}?ver={{ theme_ver }}"></script>
   {% endif %}
+  {% endif %} 
   
 {%- endblock %}

--- a/src/crate/theme/rtd/crate/sidebar.html
+++ b/src/crate/theme/rtd/crate/sidebar.html
@@ -1,6 +1,10 @@
 <div role="complementary" class="bs-docs-sidebar hidden-print">
   <div class="search-link">
+    {% if pagename == "search" %}
+    <a href="search.html" class="btn btn-primary">Search</a>
+    {% else %}
     <a href="{{ pathto('search') }}" class="btn btn-primary">Search</a>
+    {% endif %}
   </div>
   <ul class="bs-docs-sidenav bs-sidenav nav" role="complementary">
 

--- a/src/crate/theme/rtd/crate/static/css/crateio.css
+++ b/src/crate/theme/rtd/crate/static/css/crateio.css
@@ -891,6 +891,7 @@ a.learn-more-link, .wrapper-teaser-img p {
   padding-top: 10px;
   padding-bottom: 10px;
   border: 1px solid #e7e7e7;
+  background: #fff;
 }
 
 .toggle-icon {

--- a/src/crate/theme/rtd/crate/static/js/search.js
+++ b/src/crate/theme/rtd/crate/static/js/search.js
@@ -73,22 +73,22 @@ var query = urlParams.get("q");
 if (query && query.length != 0) {
   var searchBox = document.getElementById("cr-search-query");
   searchBox.value = query;
+
+  var start = document.URL.substr(document.URL.indexOf("start=") + 6, 2);
+  if (start === "1&" || document.URL.indexOf("start=") === -1) start = 1;
+
+  //Load the script src dynamically to load script with query to call.
+  // DOM: Create the script element
+  var jsElm = document.createElement("script");
+  // set the type attribute
+  jsElm.type = "application/javascript";
+  // make the script element load file
+  jsElm.src =
+    `https://www.googleapis.com/customsearch/v1/siterestrict?key=${google_search_api_key}&cx=${google_search_cx_id}&start=` +
+    start +
+    "&q=" +
+    query +
+    "&callback=hndlr";
+  // finally insert the element to the body element in order to load the script
+  document.body.appendChild(jsElm);
 }
-
-var start = document.URL.substr(document.URL.indexOf("start=") + 6, 2);
-if (start === "1&" || document.URL.indexOf("start=") === -1) start = 1;
-
-//Load the script src dynamically to load script with query to call.
-// DOM: Create the script element
-var jsElm = document.createElement("script");
-// set the type attribute
-jsElm.type = "application/javascript";
-// make the script element load file
-jsElm.src =
-  `https://www.googleapis.com/customsearch/v1/siterestrict?key=${google_search_api_key}&cx=${google_search_cx_id}&start=` +
-  start +
-  "&q=" +
-  query +
-  "&callback=hndlr";
-// finally insert the element to the body element in order to load the script
-document.body.appendChild(jsElm);


### PR DESCRIPTION
- Search was triggered by default which resulted in searching for null, which is not great for obvious reasons, this should only happen now if a query word is supplied
- Sidebar: when already on `search.html`, you couldn't click the search-link again because it was replaced with `#`
- Layout: Only load the `search.js` when actually visiting the search page, not when api credentials are supplied
- added `background: #fff;` to the version-toggler (in case of overlapping admonitions)

## Summary of the changes / Why this is an improvement


## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
