### PR TITLE
Admonition box for display on documentation of older releases

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ CHANGES
 Unreleased
 ----------
 
+- Add admonition box for display on documentation of older releases
+
 
 2022/03/01 0.21.2
 -----------------

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -155,6 +155,7 @@ bundle-assets:
 dev: $(CLONE_DIR)
 	@ $(MAKE) version-warn
 	@ $(MAKE) bundle-assets
+	@ touch index.rst
 	@ $(SRC_MAKE) $@
 
 .PHONY: html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,3 +8,26 @@ html_context = {
     "conf_py_path": "/docs/",
     "source_suffix": source_suffix,
 }
+
+
+# Enable version chooser element `version-select-container` by providing
+# corresponding attributes as propagated by readthedocs.
+html_context.update({
+
+    # Turn on versioning and announce the current version the user is displaying.
+    "versioning": True,
+    "current_version": "2.2",
+
+    # List of available versions, for populating the version chooser.
+    # Tuples of `slug, url`, but `slug` is not used.
+    "versions": [
+        ["latest", None],
+        ["older", None],
+        ["2.4", None],
+        ["2.2", None],
+        ["1.2", None],
+    ],
+
+    # Needed for computing the appropriate URL, see `layout.html`.
+    "rtd_language": "en",
+})

--- a/src/crate/theme/rtd/crate/layout.html
+++ b/src/crate/theme/rtd/crate/layout.html
@@ -48,6 +48,16 @@
             {% endblock %}
           </aside>
         </div>
+        {# Admonition box for display on documentation of older releases. #}
+        {%- if current_version is defined and versions is defined and old_versions is defined %}
+        <script type="text/javascript">
+            const rtd_versioning = {
+                current_version: "{{ current_version }}",
+                versions: "{{ versions }}",
+                old_versions: "{{ old_versions }}",
+            };
+        </script>
+        {%- endif %}
         <div class="col-md-8 col-lg-9" role="main">
           <div class="wrapper-content-right">
             {%- if current_version %}

--- a/src/crate/theme/rtd/crate/static/js/custom.js
+++ b/src/crate/theme/rtd/crate/static/js/custom.js
@@ -163,3 +163,38 @@
     headerSize();
   });
 })(jQuery);
+
+
+// Admonition box for display on documentation of older releases.
+$(document).ready(function () {
+
+  // Guard against non-availability of relevant information, injected from `layout.html`.
+  if (typeof(rtd_versioning) == "undefined") {
+    console.warn("Disabling `old_versions` admonitions, no `rtd_versioning` information found.");
+    return;
+  }
+
+  // Display `rtd_versioning` information.
+  console.info(`current_version: ${rtd_versioning.current_version}`);
+  console.info(`versions: ${rtd_versioning.versions}`);
+  console.info(`old_versions: ${rtd_versioning.old_versions}`);
+
+  // Only display the box on documentation pages for older releases.
+  if (!rtd_versioning.old_versions.includes(rtd_versioning.current_version)) {
+    return;
+  }
+
+  // Find page header element of content area.
+  const header = $(".wrapper-content-right").find("h1");
+
+  // Add admonition box.
+  const admonition = $(`
+    <div class="admonition caution">
+      <p class="admonition-title">Note</p>
+      You are reading the documentation for software release version ${rtd_versioning.current_version},
+      while a newer release is already available.
+      If you are using a different release, please make sure to select the corresponding documentation version.
+    </div>
+  `);
+  admonition.insertAfter(header);
+});


### PR DESCRIPTION
Hi there,

this patch generalizes https://github.com/crate/crate/pull/12167 by @jayeff (thank you!), so that it can be used on all documentation projects. More importantly, it aims to be a hands-off variant not needing any kind of manual interaction or maintenance, as suggested by @seut.

It adds an admonition box to documentation pages for "older" software releases to make readers aware that they are not looking at corresponding most recent version available.

The implementation is twofold:
1. A Sphinx routine reads the `current_version` and `versions` attributes from the `html_context` propagated by readthedocs and computes a list of `old_versions`, containing all numeric version labels (slugs), omitting the highest release version.
2. A JavaScript routine will display the admonition box `if current_version in old_versions`.

With kind regards,
Andreas.
