### PR TITLE
Mitigate double include of `pygments.css`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ CHANGES
 Unreleased
 ----------
 
+- Mitigate double include of ``pygments.css``
+
 
 2022/03/01 0.21.2
 -----------------

--- a/src/crate/theme/rtd/crate/base.html
+++ b/src/crate/theme/rtd/crate/base.html
@@ -115,7 +115,6 @@
 
 {%- macro css() %}
     <link rel="stylesheet" href="{{ pathto('_static/' + style, 1) }}?ver={{ theme_ver }}" type="text/css" />
-    <link rel="stylesheet" href="{{ pathto('_static/pygments.css', 1) }}?ver={{ theme_ver }}" type="text/css" />
     {%- for cssfile in css_files %}
     <link rel="stylesheet" href="{{ pathto(cssfile, 1) }}?ver={{ theme_ver }}" type="text/css" />
     {%- endfor %}


### PR DESCRIPTION
Hi,

@msbt discovered this:
```
<link rel="stylesheet" href="_static/basic.css?ver=0.21.2" type="text/css" />
<link rel="stylesheet" href="_static/pygments.css?ver=0.21.2" type="text/css" />
<link rel="stylesheet" href="_static/pygments.css?ver=0.21.2" type="text/css" />
<link rel="stylesheet" href="_static/basic.css?ver=0.21.2" type="text/css" />
<link rel="stylesheet" href="_static/copybutton.css?ver=0.21.2" type="text/css" />
<link rel="stylesheet" href="https://assets.readthedocs.org/static/css/badge_only.css?ver=0.21.2" type="text/css" />
```

Apparently, `pygments.css` will be automatically pulled in from more recent versions of Sphinx [^1].

With kind regards,
Andreas.

[^1]: https://github.com/sphinx-doc/sphinx/blob/v4.4.0/sphinx/builders/html/__init__.py#L298
