### PR TITLE
Attempt to make RTD footer and version data injection work

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Unreleased
 ----------
 
 - Mitigate double include of ``pygments.css``
+- Attempt to make RTD footer and version data injection work in reverse proxy scenarios
 
 
 2022/03/01 0.21.2

--- a/src/crate/theme/rtd/conf/__init__.py
+++ b/src/crate/theme/rtd/conf/__init__.py
@@ -154,4 +154,15 @@ def setup(app):
             app_inited.env.config.html_context["canonical_url"] = canonical_url
             app_inited.builder.config.html_context["canonical_url"] = canonical_url
 
+    # Dynamically set the `proxied_api_host` context variable on a per-project level.
+    def set_proxied_api_host(app_inited):
+        try:
+            html_context = app_inited.env.config.html_context
+            proxied_api_host = html_context["html_baseurl"] + "/_"
+            app_inited.env.config.html_context["proxied_api_host"] = proxied_api_host
+            app_inited.builder.config.html_context["proxied_api_host"] = proxied_api_host
+        except Exception as ex:
+            print(f"ERROR: Unable to adjust `proxied_api_host`. Reason: {ex}")
+
     app.connect("builder-inited", force_canonical_url)
+    app.connect("builder-inited", set_proxied_api_host)


### PR DESCRIPTION
Hi,

coming from https://github.com/crate/crate-docs-theme/issues/323, this patch attempts to make _RTD footer and version data injection_ work. Apparently, the `proxied_api_host` context variable can be used to adjust the relevant functionality [^1].

In order to make query string parameters forwarding work, it will need to be accompanied by another patch to the Nginx reverse proxy configuration, see https://github.com/crate/infrastructure/pull/2850.

With kind regards,
Andreas.

P.S.: For demonstration purposes, we chose to use the `crate-howtos` project. Without this patch, corresponding requests are directed to [1], which is clearly wrong. Now, requests will hopefully be directed to [2]. This has not been tested yet.

[1] https://crate.io/_/api/v2/footer_html/
[2] https://crate.io/docs/crate/howtos/_/api/v2/footer_html/?project=crate-howtos&version=latest

[^1]: What we are mainly targeting here, is one of the endpoints documented within the [RTD Undocumented resources and endpoints](https://docs.readthedocs.io/en/stable/api/v2.html#undocumented-resources-and-endpoints) section:
      > Endpoints for returning footer and version data to be injected into docs. (`/api/v2/footer_html`)
