### PR TITLE
Adjust `proxied_api_host` once more to fix RTD API access

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,11 +7,19 @@ Unreleased
 ----------
 
 
+2022/03/25 0.21.4
+-----------------
+
+- Adjust ``proxied_api_host`` once more to fix RTD API access in reverse proxy
+  scenarios
+
+
 2022/03/25 0.21.3
 -----------------
 
 - Mitigate double include of ``pygments.css``
-- Attempt to make RTD footer and version data injection work in reverse proxy scenarios
+- Adjust ``proxied_api_host`` to make RTD footer and version data injection work
+  in reverse proxy scenarios
 - Adjust dependencies to use Sphinx<4 and Jinja2<3.1
 
 

--- a/src/crate/theme/rtd/__init__.py
+++ b/src/crate/theme/rtd/__init__.py
@@ -23,7 +23,7 @@
 
 import os
 
-VERSION = (0, 21, 3)
+VERSION = (0, 21, 4)
 
 __version__ = ".".join(str(v) for v in VERSION)
 __version_full__ = __version__

--- a/src/crate/theme/rtd/conf/__init__.py
+++ b/src/crate/theme/rtd/conf/__init__.py
@@ -157,10 +157,18 @@ def setup(app):
     # Dynamically set the `proxied_api_host` context variable on a per-project level.
     def set_proxied_api_host(app_inited):
         try:
-            html_context = app_inited.env.config.html_context
-            proxied_api_host = html_context["html_baseurl"] + "/_"
+
+            # Compute appropriate per-project `proxied_api_host`.
+            html_baseurl = app_inited.env.config.html_baseurl.strip("/")
+            proxied_api_host = html_baseurl + "/_"
+
+            # Propagate the `proxied_api_host` to different contexts by trial-and-error.
+            app_inited.env.config.proxied_api_host = proxied_api_host
+            app_inited.builder.config.proxied_api_host = proxied_api_host
             app_inited.env.config.html_context["proxied_api_host"] = proxied_api_host
             app_inited.builder.config.html_context["proxied_api_host"] = proxied_api_host
+            print(f"INFO: Adjusted `proxied_api_host` to {proxied_api_host}")
+
         except Exception as ex:
             print(f"ERROR: Unable to adjust `proxied_api_host`. Reason: {ex}")
 


### PR DESCRIPTION
Hi,

after #326 didn't quite make it, this is another attempt to fix it. The area where the error was coming from was now validated on behalf of the `crash` project [^1], so at least this patch has more substance than the previous one.

With kind regards,
Andreas.

[^1]: While on it, https://github.com/crate/crash/pull/365 has been submitted.
