### PR TITLE
Add "html_context" variable to main configuration blueprint

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ CHANGES
 Unreleased
 ----------
 
+- Add ``html_context`` variable to main configuration blueprint
+
 
 2022/03/25 0.21.4
 -----------------

--- a/src/crate/theme/rtd/conf/__init__.py
+++ b/src/crate/theme/rtd/conf/__init__.py
@@ -37,6 +37,10 @@ extensions = [
     "sphinx_copybutton",
 ]
 
+# When not run on RTD, "html_context" is missing as a global variable
+if "html_context" not in globals():
+    html_context = {}
+
 # Configure the theme
 html_theme = "crate"
 html_theme_path = theme.get_html_theme_path()


### PR DESCRIPTION
The conf.py-wide global `html_context` variable is set by RTD. Now, we also set it locally when running the documentation builds in sandbox mode.

In this way, it is much more easy to toggle different RTD features like disabling the GitHub feedback box.

```python
# Disable GitHub feedback box for this project.
html_context.update({"display_github": False})
```
