### PR TITLE
Fix typo within header banner for "SQL-99 Complete, Really"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,15 +6,17 @@ CHANGES
 Unreleased
 ----------
 
+- Fix typo within "SQL-99 Complete, Really"
+
 
 2022/03/29 0.22.0
 -----------------
 
 - Add ``html_context`` variable to main configuration blueprint
 - Fixed mobile view on ``search.html``
-- Provide different design for "SQL99 Complete, Really" in order to more clearly
+- Provide different design for "SQL-99 Complete, Really" in order to more clearly
   separate it from the other documentation projects
-- Use Sphinx-native search for "SQL99 Complete, Really"
+- Use Sphinx-native search for "SQL-99 Complete, Really"
 - Change primary font to ``Inter`` and secondary to ``Poppins``, remove ``Blender``
 - Prevent console errors when no navbar is available
 - Disable GitHub feedback box on the SQL-99 project

--- a/src/crate/theme/rtd/crate/layout.html
+++ b/src/crate/theme/rtd/crate/layout.html
@@ -47,7 +47,7 @@
       <div class="section cr-sql-99-bg-color" style="margin: 0px;">
         <div class="cr-sql-99-header">
           <div class="cr-sql-99-headline">
-            <p>The book <span style="font-weight: 600;">SQL99 Complete, Really</span> is brought to you by</p>
+            <p>The book <span style="font-weight: 600;">SQL-99 Complete, Really</span> is brought to you by</p>
             <a href="https://crate.io" title="Crate.io">
               <img class="cr-sql-99-logo" src="{{ pathto('_static', 1) }}/images/crate-logo-white.svg" width="150" alt="Crate.io Logo White">
             </a>


### PR DESCRIPTION
Fix small typo within header banner.

![image](https://user-images.githubusercontent.com/453543/160652136-45c31cec-2ab4-48e1-a370-1e5a418433f9.png)
