### PR TITLE
Add an option to adjust the `html_context` of individual projects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Unreleased
 ----------
 
 - Fix typo within "SQL-99 Complete, Really"
+- Add an option to adjust the ``html_context`` of individual projects,
+  for disabling the GitHub feedback box on the SQL-99 project.
 
 
 2022/03/29 0.22.0

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,10 +1,22 @@
 from crate.theme.rtd.conf.fake import *
 
-html_context = {
+# Mimic some bits of the RTD context to be propagated to its Sphinx builder.
+# https://github.com/readthedocs/readthedocs.org/blob/main/readthedocs/doc_builder/backends/sphinx.py
+html_context.update({
     "display_github": True,
     "github_user": "crate",
     "github_repo": "crate-docs-theme",
     "github_version": "main",
     "conf_py_path": "/docs/",
     "source_suffix": source_suffix,
-}
+})
+
+
+# `html_context_custom` will be applied to the HTML context after the RTD
+# builder was initialized.
+
+# This snippet disables the GitHub feedback area for demonstration purposes.
+# It can be used on individual projects where this is needed.
+html_context_custom.update({
+    #"display_github": False,
+})

--- a/src/crate/theme/rtd/conf/__init__.py
+++ b/src/crate/theme/rtd/conf/__init__.py
@@ -40,6 +40,8 @@ extensions = [
 # When not run on RTD, "html_context" is missing as a global variable
 if "html_context" not in globals():
     html_context = {}
+if "html_context_custom" not in globals():
+    html_context_custom = {}
 
 # Configure the theme
 html_theme = "crate"
@@ -176,5 +178,19 @@ def setup(app):
         except Exception as ex:
             print(f"ERROR: Unable to adjust `proxied_api_host`. Reason: {ex}")
 
+    # Apply all attributes from `html_context_custom` to `html_context`.
+    def apply_html_context_custom(app_inited):
+        try:
+            if html_context_custom:
+                app_inited.env.config.html_context.update(html_context_custom)
+                app_inited.builder.config.html_context.update(html_context_custom)
+                print(f"INFO: Adjusted `html_context` with {html_context_custom}")
+            else:
+                print(f"INFO: No adjustments to `html_context`")
+
+        except Exception as ex:
+            print(f"ERROR: Unable to adjust `html_context`. Reason: {ex}")
+
     app.connect("builder-inited", force_canonical_url)
     app.connect("builder-inited", set_proxied_api_host)
+    app.connect("builder-inited", apply_html_context_custom)

--- a/src/crate/theme/rtd/conf/sql_99.py
+++ b/src/crate/theme/rtd/conf/sql_99.py
@@ -42,8 +42,8 @@ html_theme_options.update(
 
 ogp_site_url = html_baseurl
 
-html_context.update(
-    {
-        "display_github": False
-    }
-)
+
+# Disable the GitHub feedback area.
+html_context_custom.update({
+    "display_github": False,
+})


### PR DESCRIPTION
Hi again,

to make 677874ee183fe2 by @msbt work, this patch is needed for individually disabling the GitHub feedback box on the SQL-99 project.

The reason is that the `html_context` of RTD's Sphinx builder [^1] must be augmented after it has been initialized. We haven't been able to find the place where to actually adjust variables like `display_github` elsewhere.

So, we introduced another generic `html_context_custom` dictionary, where individual projects can drop customized settings into. Those settings will then be propagated to the RTD Sphinx builder appropriately, essentially overwriting the previous default settings.

With kind regards,
Andreas.

[^1]: https://github.com/readthedocs/readthedocs.org/blob/main/readthedocs/doc_builder/backends/sphinx.py
