### PR TITLE
Replace `jquery-cookie` with `js-cookie`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Unreleased
 
 - Fix copying multi-line console snippets with ``sphinx-copybutton``
 - Update JavaScript dependencies across the board
+- Replace ``jquery-cookie`` with ``js-cookie``
 
 
 2022/07/13 0.25.0

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "css-loader": "^5.2.7",
     "expose-loader": "^4.0.0",
     "jquery": "^3.6.0",
-    "jquery.cookie": "^1.4.1",
+    "js-cookie": "^3.0.1",
     "normalize.css": "^8.0.1",
     "sticky-sidebar": "^3.3.1",
     "style-loader": "^3.3.1",

--- a/src/crate/theme/rtd/crate/layout.html
+++ b/src/crate/theme/rtd/crate/layout.html
@@ -220,7 +220,7 @@
   <script>
     !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on","setAnonymousId"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t){var e=document.createElement("script");e.type="text/javascript";e.async=!0;e.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};analytics.SNIPPET_VERSION="4.0.0";
       analytics.load("{{ theme_tracking_segment_id }}");
-      analytics.setAnonymousId(jquery.cookie('uid'));
+      analytics.setAnonymousId(Cookies.get('uid'));
       analytics.page('{{ title|striptags }} - {{ docstitle|striptags }}', {
         project: '{{ theme_tracking_project }}',
         version: '{{ current_version }}'

--- a/src/crate/theme/rtd/crate/static/js/index.js
+++ b/src/crate/theme/rtd/crate/static/js/index.js
@@ -1,5 +1,5 @@
 import "jquery";
-import "jquery.cookie";
+import Cookies from "js-cookie";
 import "sticky-sidebar";
 
 import "./webflow";

--- a/yarn.lock
+++ b/yarn.lock
@@ -615,15 +615,15 @@ jest-worker@^27.4.5:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-jquery.cookie@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/jquery.cookie/-/jquery.cookie-1.4.1.tgz#d63dce209eab691fe63316db08ca9e47e0f9385b"
-  integrity sha1-1j3OIJ6raR/mMxbbCMqeR+D5OFs=
-
 jquery@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
   integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==
+
+js-cookie@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.1.tgz#9e39b4c6c2f56563708d7d31f6f5f21873a92414"
+  integrity sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==
 
 json-parse-even-better-errors@^2.3.1:
   version "2.3.1"


### PR DESCRIPTION
The most recent version of `jquery-cookie` was published 8 years ago already. On the other hand, `js-cookie` is still being maintained.