### PR TITLE
Fix copying multi-line console snippets with `sphinx-copybutton`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ CHANGES
 Unreleased
 ----------
 
+- Fix copying multi-line console snippets with ``sphinx-copybutton``
+
 
 2022/07/13 0.25.0
 -----------------

--- a/docs/codesnippets.rst
+++ b/docs/codesnippets.rst
@@ -72,9 +72,31 @@ Configuration files
 Terminal commands
 =================
 
+Single-line
+-----------
+
 .. code-block:: sh
 
     sh$ csvsql --db crate://localhost:4200 --insert /tmp/dump.csv
+
+.. code-block:: sh
+
+    $ sh iss-position.sh
+
+    CONNECT OK
+    INSERT OK, 1 row affected  (0.029 sec)
+    Sleeping for 10 seconds...
+
+Multi-line
+----------
+
+.. code-block:: sh
+
+    sh$ crash --hosts localhost:4200 \
+            --command "INSERT INTO iss (position) VALUES ('$(wkt_position)')"
+
+    CONNECT OK
+    INSERT OK, 1 row affected  (0.037 sec)
 
 
 Code blocks

--- a/src/crate/theme/rtd/conf/__init__.py
+++ b/src/crate/theme/rtd/conf/__init__.py
@@ -122,6 +122,7 @@ ogp_type = "website"
 
 # Configure Sphinx-copybutton
 copybutton_remove_prompts = True
+copybutton_line_continuation_character = "\\"
 copybutton_prompt_text = r">>> |\.\.\. |\$ |sh\$ |PS> |cr> |mysql> |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
 copybutton_prompt_is_regexp = True
 


### PR DESCRIPTION
This is a fix for #354, following @msbt's suggestion to add the `copybutton_line_continuation_character = "\\"` configuration setting.