### PR TITLE
Fix webpack expose configuration for `js-cookie` library

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ CHANGES
 Unreleased
 ----------
 
+- Fix webpack expose configuration for ``js-cookie`` library
+
 
 2022/07/22 0.26.0
 -----------------

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,6 +25,14 @@ module.exports = {
                     exposes: ["$", "jquery", "jQuery"],
                 },
             },
+            {
+                // Expose `js-cookie` for use outside Webpack build.
+                test: require.resolve('js-cookie'),
+                loader: "expose-loader",
+                options: {
+                    exposes: ["Cookies"],
+                },
+            },
         ],
     },
     resolve: {


### PR DESCRIPTION
This patch aims to fix #356.

![image](https://user-images.githubusercontent.com/453543/180756775-42179889-9684-4f2b-9b79-953c6a89e10a.png)
