### PR TITLE
Fix `js-cookie` library import

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ CHANGES
 Unreleased
 ----------
 
+- Fix ``js-cookie`` library import
+
 
 2022/07/25 0.26.1
 -----------------

--- a/src/crate/theme/rtd/crate/static/js/index.js
+++ b/src/crate/theme/rtd/crate/static/js/index.js
@@ -1,5 +1,5 @@
 import "jquery";
-import Cookies from "js-cookie";
+import * as Cookies from "js-cookie";
 import "sticky-sidebar";
 
 import "./webflow";


### PR DESCRIPTION
Hi again,

#359 did not fix the problem. This is another attempt, based on findings at [^1] and [^2].

With kind regards,
Andreas.

[^1]: https://github.com/js-cookie/js-cookie/issues/201#issuecomment-971261916
[^2]: https://stackoverflow.com/questions/59234564/how-to-correctly-require-js-cookie-with-npm-and-webpack-uncaught-referenceerror
