### PR TITLE
CTAs for SQL-99 and Cookie-Fix

### DIFF
--- a/src/crate/theme/rtd/crate/layout.html
+++ b/src/crate/theme/rtd/crate/layout.html
@@ -61,8 +61,10 @@
           </div>
 
           <div class="cr-sql-99-cta">
-            <a href="https://crate.io/lp-free-trial" target="_blank" class="btn btn-primary btn-cr-sql-99">Try CrateDB Cloud for free</a>
-            <p><a href="https://crate.io/products/cratedb/" target="_blank" class="cr-sql-99-link">Learn more about CrateDB</a></p>
+            <!--HubSpot Call-to-Action Code --><span class="hs-cta-wrapper" id="hs-cta-wrapper-ec50412c-3f36-4d63-be45-bd906b6f07e7"><span class="hs-cta-node hs-cta-ec50412c-3f36-4d63-be45-bd906b6f07e7" id="hs-cta-ec50412c-3f36-4d63-be45-bd906b6f07e7"><!--[if lte IE 8]><div id="hs-cta-ie-element"></div><![endif]--><a href="https://cta-redirect.hubspot.com/cta/redirect/19927462/ec50412c-3f36-4d63-be45-bd906b6f07e7" target="_blank" rel="noopener"><img class="hs-cta-img" id="hs-cta-img-ec50412c-3f36-4d63-be45-bd906b6f07e7" style="border-width:0px;" src="https://no-cache.hubspot.com/cta/default/19927462/ec50412c-3f36-4d63-be45-bd906b6f07e7.png"  alt="Try CrateDB Cloud for free"/></a></span><script charset="utf-8" src="https://js.hscta.net/cta/current.js"></script><script type="text/javascript"> hbspt.cta.load(19927462, 'ec50412c-3f36-4d63-be45-bd906b6f07e7', {"useNewLoader":"true","region":"na1"}); </script></span><!-- end HubSpot Call-to-Action Code -->
+            <p>
+              <!--HubSpot Call-to-Action Code --><span class="hs-cta-wrapper" id="hs-cta-wrapper-8f8bc143-e23d-4454-9a8c-f9a2d4821973"><span class="hs-cta-node hs-cta-8f8bc143-e23d-4454-9a8c-f9a2d4821973" id="hs-cta-8f8bc143-e23d-4454-9a8c-f9a2d4821973"><!--[if lte IE 8]><div id="hs-cta-ie-element"></div><![endif]--><a href="https://cta-redirect.hubspot.com/cta/redirect/19927462/8f8bc143-e23d-4454-9a8c-f9a2d4821973" target="_blank" rel="noopener"><img class="hs-cta-img" id="hs-cta-img-8f8bc143-e23d-4454-9a8c-f9a2d4821973" style="border-width:0px;" src="https://no-cache.hubspot.com/cta/default/19927462/8f8bc143-e23d-4454-9a8c-f9a2d4821973.png"  alt="Learn more about CrateDB"/></a></span><script charset="utf-8" src="https://js.hscta.net/cta/current.js"></script><script type="text/javascript"> hbspt.cta.load(19927462, '8f8bc143-e23d-4454-9a8c-f9a2d4821973', {"useNewLoader":"true","region":"na1"}); </script></span><!-- end HubSpot Call-to-Action Code -->
+            </p>
           </div>
         </div>
       </div>

--- a/src/crate/theme/rtd/crate/static/js/custom.js
+++ b/src/crate/theme/rtd/crate/static/js/custom.js
@@ -178,3 +178,5 @@
   });
 
 })(jQuery);
+
+var Cookies = require('js-cookie');


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

This adds HubSpot CTAs on SQL-99 to track clicks and also _should_ fix the Cookies error introduced with https://github.com/crate/crate-docs-theme/pull/356