### PR TITLE
Fix visual appearance of Intersphinx references per `xref` CSS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,10 @@ CHANGES
 Unreleased
 ----------
 
+- Fix visual appearance of Intersphinx references per ``xref`` CSS.
+  Don't render links in bold text when using custom label. Happens,
+  for example, with ``:class:dictionaries <py:dict>``.
+
 
 2022/09/05 0.26.3
 -----------------

--- a/src/crate/theme/rtd/crate/static/css/crateio-rtd.css
+++ b/src/crate/theme/rtd/crate/static/css/crateio-rtd.css
@@ -185,6 +185,10 @@ a code {
     font-weight: normal;
 }
 
+code.xref, a code {
+  font-weight: normal !important;
+}
+
 div.topic {
     border: 0;
 }


### PR DESCRIPTION
This patch originates from https://github.com/crate/crate-python/pull/487. It tweaks the `xref` CSS class so that it does not render links in bold text when using a custom label. Happens, for example, with `:class:dictionaries <py:dict>`.
