### PR TITLE
mergify: Remove deprecated `rebase_fallback` option

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -18,4 +18,3 @@ pull_request_rules:
       queue:
         method: rebase
         name: default
-        rebase_fallback: none


### PR DESCRIPTION
The Mergify configuration used the deprecated `rebase_fallback` mode of the queue and/or merge action.

- https://docs.mergify.com/actions/queue/#queue-action
- https://github.com/crate/crate/pull/13483/checks
