### PR TITLE
remove code-tag from mobile override

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ Unreleased
 - Use relative links to pages
 - Update opengraph image
 - Enable meta description via ``ogp_enable_meta_description = True``
+- Removed ``code``-tag from a mobile media query to fix headlines font-sizes
 
 
 2022/12/29 0.26.5

--- a/src/crate/theme/rtd/crate/static/css/custom.css
+++ b/src/crate/theme/rtd/crate/static/css/custom.css
@@ -718,7 +718,6 @@ body .mm-menu .navbar-nav {
     font-size: 14px;
   }
 
-  code,
   kbd,
   pre,
   samp {


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

This removed the `code`-tag from the mobile media query which would change the font-size.


## Rationale
Embedded `code` markup within headlines has been assigned an unfortunate font size within the styling variant for smaller devices.

![image](https://github.com/crate/crate-docs-theme/assets/453543/6e264991-0e0b-4fc5-bec4-1b8712b9e189)

-- https://crate-python--553.org.readthedocs.build/en/553/by-example/sqlalchemy/dataframe.html#efficient-insert-operations-with-pandas