### PR TITLE
Fix "font with `code` attribute too small in headline on mobile" flaw

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Unreleased
 - Use relative links to pages
 - Update opengraph image
 - Enable meta description via ``ogp_enable_meta_description = True``
+- Removed ``code``-tag from a mobile media query to fix headlines font-sizes
 
 
 2022/12/29 0.26.5

--- a/src/crate/theme/rtd/crate/static/css/custom.css
+++ b/src/crate/theme/rtd/crate/static/css/custom.css
@@ -718,7 +718,6 @@ body .mm-menu .navbar-nav {
     font-size: 14px;
   }
 
-  code,
   kbd,
   pre,
   samp {


### PR DESCRIPTION
Handing in GH-374 again because there have been troubles before.