### PR TITLE
Release 0.27.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,12 @@ Unreleased
 ----------
 
 
+2023/05/15 0.27.1
+-----------------
+
+- Removed ``code``-tag from a mobile media query to fix headlines font-sizes
+
+
 2023/04/18 0.27.0
 -----------------
 
@@ -17,7 +23,6 @@ Unreleased
 - Use relative links to pages
 - Update opengraph image
 - Enable meta description via ``ogp_enable_meta_description = True``
-- Removed ``code``-tag from a mobile media query to fix headlines font-sizes
 
 
 2022/12/29 0.26.5

--- a/src/crate/theme/rtd/__init__.py
+++ b/src/crate/theme/rtd/__init__.py
@@ -23,7 +23,7 @@
 
 import os
 
-VERSION = (0, 27, 0)
+VERSION = (0, 27, 1)
 
 __version__ = ".".join(str(v) for v in VERSION)
 __version_full__ = __version__


### PR DESCRIPTION
Publish new release with updates from GH-374/GH-375.


_Failing tests on CI can probably be attributed to Azure infrastructure.
-- https://github.com/actions/runner-images/issues/7048#issuecomment-1548182826_
