### PR TITLE
CI: Make rendering on RTD on-PR builds work

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,11 +1,23 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+
+# Details
+# - https://docs.readthedocs.io/en/stable/config-file/v2.html
+
+# Required
 version: 2
 
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.11"
+
+# Build documentation in the docs/ directory with Sphinx
 sphinx:
   builder: html
   configuration: docs/conf.py
   fail_on_warning: true
 
 python:
-  version: 3.7
   install:
     - requirements: docs/requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,6 +12,12 @@ build:
   tools:
     python: "3.11"
 
+  # Bundle assets, because `pip install --editable=.` does not do it.
+  jobs:
+    pre_build:
+      - make develop
+      - cd docs; make bundle-assets
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   builder: html

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,6 +11,8 @@ build:
   os: "ubuntu-22.04"
   tools:
     python: "3.11"
+  apt_packages:
+    - plantuml
 
   # Bundle assets, because `pip install --editable=.` does not do it.
   jobs:

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ PYTHON   := python3
 PIP      := $(ENV_BIN)/pip3
 TWINE    := $(ENV_BIN)/twine
 NODE     := $(ENV_BIN)/node
+NPM      := $(ENV_BIN)/npm
 NODEENV  := $(ENV_BIN)/nodeenv
 DIST_DIR := .dist
 PYPIRC   := ~/.pypirc
@@ -57,6 +58,8 @@ help:
 $(NODE):
 	$(PIP) install nodeenv
 	$(NODEENV) --python-virtualenv --node=$(NODEJS_VERSION)
+	. $(ACTIVATE) && \
+		npm install --global yarn
 
 $(TWINE):
 	$(PYTHON) -m venv $(ENV_DIR)
@@ -79,6 +82,7 @@ nodejs-lts: $(NODE)
 bundle-assets: nodejs-lts
 	. $(ACTIVATE) && \
 		printf "Node.js version: "; node --version && \
+		printf "Yarn version: "; yarn --version && \
 		yarn install && \
 		npx webpack --mode=production
 
@@ -86,6 +90,7 @@ bundle-assets: nodejs-lts
 develop: setup-virtualenv nodejs-lts
 	. $(ACTIVATE) && \
 		printf "Node.js version: "; node --version && \
+		printf "Yarn version: "; yarn --version && \
 		yarn install && \
 		npx webpack --mode=development
 

--- a/README.rst
+++ b/README.rst
@@ -4,12 +4,22 @@ Crate Docs Theme
 
 |tests| |rtd| |build| |pypi|
 
+
+About
+=====
+
 A `Sphinx`_ theme for the `Crate documentation`_.
 
 *Note: This theme is tightly integrated into the Crate.io website and is
 not intended for general use.*
 
-For help making changes to the theme, see the `developer docs`_.
+For making changes to the theme, see the `developer docs`_.
+
+
+Preview
+=======
+
+The demo/preview project is rendered and published to https://crate-docs-theme.readthedocs.io/.
 
 
 Using the theme

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -84,6 +84,10 @@ SELF_SRC      := $(TOP_DIR)/common-build
 SELF_MAKEFILE := $(SELF_SRC)/rules.mk
 SRC_MAKE      := $(MAKE) -f $(SRC_DIR)/rules.mk
 
+ENV_DIR       := ../.venv
+ENV_BIN       := $(ENV_DIR)/bin
+ACTIVATE      := $(ENV_BIN)/activate
+
 # Parse the JSON file
 BUILD_VERSION := $(shell cat $(BUILD_JSON) | \
     python -c 'import json, sys; print(json.load(sys.stdin)["message"])')
@@ -148,8 +152,12 @@ Makefile:
 
 .PHONY: bundle-assets
 bundle-assets:
-	cd .. && yarn install
-	cd .. && npx webpack --mode=development
+	. $(ACTIVATE) \
+		&& printf "Node.js version: "; node --version \
+		&& printf "Yarn version: "; yarn --version \
+		&& cd .. \
+		&& yarn install \
+		&& yarn webpack --mode=development
 
 .PHONY: dev
 dev: $(CLONE_DIR)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,5 +53,5 @@ How to improve this documentation:
     glossary
 
 
-.. _developer guide: https://github.com/crate/crate-docs-theme/blob/main/DEVELOP.rst#user-content-making-changes-to-the-theme
+.. _developer guide: https://github.com/crate/crate-docs-theme/blob/main/DEVELOP.rst
 .. _report an issue: https://github.com/crate/crate-docs-theme/issues/new


### PR DESCRIPTION
## Problem

There is a chicken-egg problem when running RTD preview builds on pull requests with this repository. A **release version** of the corresponding Python package already ships the bundled assets. However, the **development version** does not.

## Solution

The CI build on RTD needs to bundle resources using webpack before running the build.
