### PR TITLE
remove blockquote overrides

### DIFF
--- a/src/crate/theme/rtd/crate/static/css/crateio-rtd.css
+++ b/src/crate/theme/rtd/crate/static/css/crateio-rtd.css
@@ -24,10 +24,8 @@ a.current, a.current-active {
     background: inherit none repeat scroll 0 0;
 }
 
-blockquote {
-    font-size: 20px;
-    border-left: 0px;
-    padding: 0px 0px;
+blockquote p:last-child {
+    margin-bottom: 0;
 }
 
 /** admonitions **/


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

This removes the css overrides from the old template to allow new features to work. I also removed the margin-bottom of the last paragraph so the blockquotes are always centered.

https://github.com/crate/crate-docs-theme/pull/378#discussion_r1265560168 for reference