### PR TITLE
Refactor feedback and version chooser components

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,14 @@ on:
     branches:
       - main
 
+  # Allow job to be triggered manually.
+  workflow_dispatch:
+
+# Cancel in-progress jobs when pushing to the same branch.
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 jobs:
 
   package:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,14 @@ on:
     branches:
       - main
 
+  # Allow job to be triggered manually.
+  workflow_dispatch:
+
+# Cancel in-progress jobs when pushing to the same branch.
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 jobs:
 
   documentation:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Unreleased
 - Add modern components from the Sphinx ecosystem: myst-parser, sphinx-design,
   sphinx-inline-tabs, sphinx-subfigure, sphinx-togglebutton, sphinxcontrib-mermaid.
 - Refactor GitHub feedback component to separate files
+- Migrate version chooser component to sphinx-design dropdown
 
 
 2023/05/15 0.27.1

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Unreleased
 
 - Add modern components from the Sphinx ecosystem: myst-parser, sphinx-design,
   sphinx-inline-tabs, sphinx-subfigure, sphinx-togglebutton, sphinxcontrib-mermaid.
+- Refactor GitHub feedback component to separate files
 
 
 2023/05/15 0.27.1

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,6 +8,11 @@ html_context.update({
     "conf_py_path": "/docs/",
     "source_suffix": source_suffix,
 
+    # Enable version chooser.
+    "display_version": True,
+    "current_version": "foobar",
+    "versions": [("foobar", None), ("bazqux", None)],
+
     # Enable feedback widget and source/edit links.
     "display_github": True,
     "github_user": "crate",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,14 +1,18 @@
 from crate.theme.rtd.conf.fake import *
 
-# Mimic some bits of the RTD context to be propagated to its Sphinx builder.
+# Mimic some bits of the RTD context being propagated to its Sphinx builder.
 # https://github.com/readthedocs/readthedocs.org/blob/main/readthedocs/doc_builder/backends/sphinx.py
 html_context.update({
+
+    # Generic settings.
+    "conf_py_path": "/docs/",
+    "source_suffix": source_suffix,
+
+    # Enable feedback widget and source/edit links.
     "display_github": True,
     "github_user": "crate",
     "github_repo": "crate-docs-theme",
     "github_version": "main",
-    "conf_py_path": "/docs/",
-    "source_suffix": source_suffix,
 })
 
 

--- a/src/crate/theme/rtd/crate/github_feedback_full.html
+++ b/src/crate/theme/rtd/crate/github_feedback_full.html
@@ -1,0 +1,87 @@
+<!-- GitHub feedback component: Rating, issues, and links to files -->
+
+<div class="view-on-github">
+  <div id="cr-docs-feedback" class="cr-docs-feedback-container">
+    <div class="cr-docs-feedback-header">
+      <div class="cr-docs-feedback-headline">
+          <h2>Feedback</h2>
+      </div>
+    </div>
+
+     <div id="cr-docs-rating" class="cr-docs-rating-container cr-nojs-hide">
+        <div class="cr-rating-content">
+            <div class="cr-rating">
+              <form id="ratingForm">
+                <span class="cr-ratingtext">How helpful was this page?</span>
+                <fieldset class="rating">
+                  <input type="radio" id="star5" name="rating" value="5" /><label for="star5" title="Great!"><span class="cr-stars-label">5 stars</span></label>
+                  <input type="radio" id="star4" name="rating" value="4" /><label for="star4" title="Pretty good"><span class="cr-stars-label">4 stars</span></label>
+                  <input type="radio" id="star3" name="rating" value="3" /><label for="star3" title="Meh"><span class="cr-stars-label">3 stars</span></span></label>
+                  <input type="radio" id="star2" name="rating" value="2" /><label for="star2" title="Bad"><span class="cr-stars-label">2 stars</span></label>
+                  <input type="radio" id="star1" name="rating" value="1" /><label for="star1" title="Ugh..."><span class="cr-stars-label">1 star</span></label>
+                </fieldset>
+                <div id="ratingStatus"></div>
+                <button id="ratingVote" class="submit">Submit</button>
+              </form>
+          </div>
+        </div>
+      </div>
+
+      <div id="cr-feedback-content">
+
+      </div>
+
+      <div class="cr-docs-feedback-meta">
+        <a id="docs-feedback-open-issue" rel="noopener" href="https://{{ github_host|default('github.com') }}/{{ github_user }}/{{ github_repo }}/issues/new?labels=team:%20tech%20writing,triage&body={{
+          '###  Documentation feedback'|urlencode }}{{ '%0A'
+        }}{{ '%0A'
+        }}{{
+          '<!--Please do not edit or remove the following information -->'|urlencode }}{{ '%0A '
+        }}{{ '%0A'
+        }}{{
+          '- Page title: '|urlencode }}{{ title|striptags|urlencode }}{{ '%0A'
+        }}{{
+          '- Page URL: https://crate.io/'|urlencode }}{{ theme_canonical_url_path|urlencode }}{{ pagename|urlencode }}.html{{ '%0A'
+        }}{{
+          '- Source: https://'|urlencode }}{{ github_host|default('github.com') }}/{{ github_user }}/{{ github_repo }}/{{ theme_vcs_pageview_mode|default('blob') }}/{{ github_version }}{{ conf_py_path|urlencode }}{{ pagename|urlencode }}{{ suffix }}{{ '%0A'
+        }}{{ '%0A'
+        }}---{{ '%0A'
+        }}{{ '%0A'
+        }}{{
+          '<!-- Please add your comments here -->'|urlencode }}{{ '%0A'
+        }}{{ '%0A'
+        }}" target="_blank" title="New issue">New&nbsp;issue</a>
+        <a id="docs-feedback-edit-document" href="https://{{ github_host|default('github.com') }}/{{ github_user }}/{{ github_repo }}/{{ theme_vcs_pageview_mode|default('edit') }}/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ suffix }}" rel="noopener" target="_blank" title="Edit on GitHub">Edit&nbsp;on&nbsp;GitHub</a>
+
+        <a id="docs-feedback-open-github" href="https://{{ github_host|default('github.com') }}/{{ github_user }}/{{ github_repo }}/{{ theme_vcs_pageview_mode|default('blob') }}/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ suffix }}" rel="noopener" target="_blank" title="View on GitHub">View&nbsp;on&nbsp;GitHub</a>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+
+{% include "github_feedback_full.js" %}
+
+function main() {
+  var feedbackLoaded = false;
+
+  // Check if feedback section is in viewport.
+  var feedbackbox = document.querySelector('#cr-docs-feedback');
+  if (isInViewport(feedbackbox)) {
+    renderIssues();
+    feedbackLoaded = true;
+  }
+
+  $(window).scroll(function () {
+    if (!feedbackLoaded ){
+      if (isInViewport(feedbackbox)) {
+        renderIssues();
+        feedbackLoaded = true;
+      }
+    }
+  });
+}
+
+main();
+</script>

--- a/src/crate/theme/rtd/crate/github_feedback_full.js
+++ b/src/crate/theme/rtd/crate/github_feedback_full.js
@@ -1,0 +1,116 @@
+/**
+ * GitHub feedback component: Rating, issues, and links to files.
+**/
+function renderIssues() {
+
+    function makeIssueHeader(open, closed) {
+      var html = "<div class='cr-docs-feedback-nav'><ul> \
+      <li><a id='issues-open' class='cr-fb-link cr-fb-active' title='View Open issues'>Open (";
+
+                // if more than 30 issues, add "Last"
+                if (open.length >= 30) { html += `Last `; }
+                html += open.length + ")</a></li> \
+                <li><a id='issues-closed' class='cr-fb-link' title='View Closed issues'>Closed (";
+                if (closed.length >= 30) { html += `Last `; }
+                html += closed.length + ")</a></li> \
+                </ul></div>";
+
+                return html;
+    }
+
+    function listIssues(issues, isClosed) {
+      var divId;
+      var display;
+      if (!isClosed) {
+        divId = "cr-docs-issues-open-list";
+        display = 'block';
+      } else {
+        divId = "cr-docs-issues-closed-list";
+        display = 'none';
+      }
+      var html = `<div style='display: ${display};' id='${divId}' class='cr-docs-feedback-issues'><ul>`;
+
+      // if no issues are found, post this
+      if (issues.length == 0) { html += `<li>Currently there is no feedback for this document.</li>` }
+
+        else {
+          issues.forEach((issue) => {
+            html += `<li><div class='cr-docs-feedback-entry'><div class='cr-docs-feedback-title'><strong><a href='${issue.html_url}' rel='noopener' class='cr-docs-link' title='View issue on GitHub' target='blank'>${issue.title}</a></strong></div>`;
+
+              // show PR if applicable
+              if (issue.pull_request != undefined) {
+                html += `<div class='cr-docs-feedback-pr'><svg viewBox='0 0 12 16' version='1.1' width='12' height='16' aria-hidden='true'><path fill-rule='evenodd' d='M11 11.28V5c-.03-.78-.34-1.47-.94-2.06C9.46 2.35 8.78 2.03 8 2H7V0L4 3l3 3V4h1c.27.02.48.11.69.31.21.2.3.42.31.69v6.28A1.993 1.993 0 0010 15a1.993 1.993 0 001-3.72zm-1 2.92c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zM4 3c0-1.11-.89-2-2-2a1.993 1.993 0 00-1 3.72v6.56A1.993 1.993 0 002 15a1.993 1.993 0 001-3.72V4.72c.59-.34 1-.98 1-1.72zm-.8 10c0 .66-.55 1.2-1.2 1.2-.65 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z'><title>Pull Request</title></path></svg></div>`;
+              }
+              // show # of comments
+              if (issue.comments != 0) {
+                html += `<div class='cr-docs-feedback-comments'><a href='${issue.html_url}' rel='noopener' class='cr-docs-link' title='View issue on GitHub' target='blank'><svg viewBox='0 0 16 16' version='1.1' width='16' height='16' aria-hidden='true'><path fill-rule='evenodd' d='M14 1H2c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1h2v3.5L7.5 11H14c.55 0 1-.45 1-1V2c0-.55-.45-1-1-1zm0 9H7l-2 2v-2H2V2h12v8z'><title>Comment</title></path></svg> ${issue.comments}</a></div>`;
+              }
+              // show issue number + link to it
+              html += `</div><div class='cr-docs-feedback-details'><a href='${issue.html_url}' rel='noopener' class='cr-docs-link' title='View issue on GitHub' target='blank'>#${issue.number}</a> `;
+
+              var date = new Date(issue.created_at);
+
+              const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+              var formatted_date = date.getDate() + " "
+              + months[date.getMonth()] + " "
+              + date.getFullYear();
+
+              html += `opened on ${formatted_date} by <a href='${issue.user.html_url}' rel='noopener' class='cr-docs-link' title='View ${issue.user.login} on GitHub' `;
+              html += ` target='blank'>${issue.user.login}</a></br>`;
+              html += "</div></li>";
+            });
+        }
+
+        html += "</ul></div>";
+        return html;
+      }
+
+      async function fetchIssues(url) {
+        const data = await fetch(url).then((response) => response.json());
+        return data;
+      }
+
+      const content = document.getElementById('cr-feedback-content');
+      content.innerHTML = '<p>Loading data...</p>';
+      fetchIssues("https://api.{{ github_host|default('github.com') }}/search/issues?q=repo:{{ github_user }}/{{ github_repo }}+label%3A\"area%3A+docs\"+\"{{ title|striptags|urlencode }}\"+\"{{ pagename|urlencode }}.html\"")
+          .then(function (issues) {
+            const openIssues = issues.items.filter(x => x.state == 'open');
+            const closedIssues = issues.items.filter(x => x.state == 'closed');
+            var html = makeIssueHeader(openIssues, closedIssues);
+            html += listIssues(openIssues);
+            html += listIssues(closedIssues, true);
+            content.innerHTML = html;
+            const openButton = document.getElementById('issues-open');
+            const closedButton = document.getElementById('issues-closed');
+            const openList = document.getElementById('cr-docs-issues-open-list');
+            const closedList = document.getElementById('cr-docs-issues-closed-list');
+            openButton.addEventListener('click', function (e) {
+              openButton.classList.add('cr-fb-active');
+              closedButton.classList.remove('cr-fb-active');
+              openList.style.display = 'block';
+              closedList.style.display = 'none';
+            });
+            closedButton.addEventListener('click', function (e) {
+              openButton.classList.remove('cr-fb-active');
+              closedButton.classList.add('cr-fb-active');
+              openList.style.display = 'none';
+              closedList.style.display = 'block';
+            });
+
+          {% if theme_tracking_segment_id %}
+          analytics.track('Feedback Opened');
+          {% endif %}
+          }).catch(function() {
+          // if rate limit exceeded, throw this error
+          content.innerHTML = '<p>Error loading data, limit exceeded. Please try again later.</p>';
+          {% if theme_tracking_segment_id %}
+          analytics.track('DOCS RATE LIMIT', {
+            location: 'Center',
+            text: 'Error loading data, limit exceeded. Please try again later.',
+            category: 'Docs',
+            type: 'Text',
+            pageTitle: document.title
+         });
+         {% endif %}
+    });
+}

--- a/src/crate/theme/rtd/crate/github_keynav.js
+++ b/src/crate/theme/rtd/crate/github_keynav.js
@@ -1,0 +1,13 @@
+/**
+ * Keyboard navigation for GitHub. CTRL+G will navigate to
+ * the edit page on GitHub for the corresponding document.
+**/
+document.addEventListener('keydown', (event) => {
+  if (event.key === 'g' && event.ctrlKey) {
+    {% if check_meta and 'github_url' in meta %}
+      location.href = "{{ meta['github_url'] }}";
+    {% else %}
+      location.href = "https://{{ github_host|default('github.com') }}/{{ github_user }}/{{ github_repo }}/{{ theme_vcs_pageview_mode|default('edit') }}/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ suffix }}";
+    {% endif %}
+  }
+});

--- a/src/crate/theme/rtd/crate/layout.html
+++ b/src/crate/theme/rtd/crate/layout.html
@@ -111,65 +111,8 @@
           </div>
 
           {% if display_github %}
-          <div class="view-on-github">
-            <div id="cr-docs-feedback" class="cr-docs-feedback-container">
-              <div class="cr-docs-feedback-header">
-                <div class="cr-docs-feedback-headline">
-                    <h2>Feedback</h2>
-                </div>
-              </div>
-
-               <div id="cr-docs-rating" class="cr-docs-rating-container cr-nojs-hide">
-                  <div class="cr-rating-content">
-                      <div class="cr-rating">
-                        <form id="ratingForm">
-                          <span class="cr-ratingtext">How helpful was this page?</span>
-                          <fieldset class="rating">
-                            <input type="radio" id="star5" name="rating" value="5" /><label for="star5" title="Great!"><span class="cr-stars-label">5 stars</span></label>
-                            <input type="radio" id="star4" name="rating" value="4" /><label for="star4" title="Pretty good"><span class="cr-stars-label">4 stars</span></label>
-                            <input type="radio" id="star3" name="rating" value="3" /><label for="star3" title="Meh"><span class="cr-stars-label">3 stars</span></span></label>
-                            <input type="radio" id="star2" name="rating" value="2" /><label for="star2" title="Bad"><span class="cr-stars-label">2 stars</span></label>
-                            <input type="radio" id="star1" name="rating" value="1" /><label for="star1" title="Ugh..."><span class="cr-stars-label">1 star</span></label>
-                          </fieldset>
-                          <div id="ratingStatus"></div>
-                          <button id="ratingVote" class="submit">Submit</button>
-                        </form>
-                    </div>
-                  </div>
-                </div>
-
-                <div id="cr-feedback-content">
-
-                </div>
-
-                <div class="cr-docs-feedback-meta">
-                  <a id="docs-feedback-open-issue" rel="noopener" href="https://{{ github_host|default('github.com') }}/{{ github_user }}/{{ github_repo }}/issues/new?labels=team:%20tech%20writing,triage&body={{
-                    '###  Documentation feedback'|urlencode }}{{ '%0A'
-                  }}{{ '%0A'
-                  }}{{
-                    '<!--Please do not edit or remove the following information -->'|urlencode }}{{ '%0A '
-                  }}{{ '%0A'
-                  }}{{
-                    '- Page title: '|urlencode }}{{ title|striptags|urlencode }}{{ '%0A'
-                  }}{{
-                    '- Page URL: https://crate.io/'|urlencode }}{{ theme_canonical_url_path|urlencode }}{{ pagename|urlencode }}.html{{ '%0A'
-                  }}{{
-                    '- Source: https://'|urlencode }}{{ github_host|default('github.com') }}/{{ github_user }}/{{ github_repo }}/{{ theme_vcs_pageview_mode|default('blob') }}/{{ github_version }}{{ conf_py_path|urlencode }}{{ pagename|urlencode }}{{ suffix }}{{ '%0A'
-                  }}{{ '%0A'
-                  }}---{{ '%0A'
-                  }}{{ '%0A'
-                  }}{{
-                    '<!-- Please add your comments here -->'|urlencode }}{{ '%0A'
-                  }}{{ '%0A'
-                  }}" target="_blank" title="New issue">New&nbsp;issue</a>
-                  <a id="docs-feedback-edit-document" href="https://{{ github_host|default('github.com') }}/{{ github_user }}/{{ github_repo }}/{{ theme_vcs_pageview_mode|default('edit') }}/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ suffix }}" rel="noopener" target="_blank" title="Edit on GitHub">Edit&nbsp;on&nbsp;GitHub</a>
-
-                  <a id="docs-feedback-open-github" href="https://{{ github_host|default('github.com') }}/{{ github_user }}/{{ github_repo }}/{{ theme_vcs_pageview_mode|default('blob') }}/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ suffix }}" rel="noopener" target="_blank" title="View on GitHub">View&nbsp;on&nbsp;GitHub</a>
-                </div>
-              </div>
-            </div>
-          </div>
-          {% endif %}
+          {% include "github_feedback_full.html" %}
+          {%- endif %}
 
         </div>
       </div>
@@ -183,15 +126,7 @@
 
   {% if display_github %}
   <script>
-    document.addEventListener('keydown', (event) => {
-      if (event.key === 'g' && event.ctrlKey) {
-        {% if check_meta and 'github_url' in meta %}
-          location.href = "{{ meta['github_url'] }}";
-        {% else %}
-          location.href = "https://{{ github_host|default('github.com') }}/{{ github_user }}/{{ github_repo }}/{{ theme_vcs_pageview_mode|default('edit') }}/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ suffix }}";
-        {% endif %}
-      }
-    });
+  {%- include "github_keynav.js" %}
   </script>
   {% endif %}
 
@@ -235,152 +170,6 @@
   <!-- Start of HubSpot Embed Code -->
   <script type="text/javascript" id="hs-script-loader" async defer src="//js.hs-scripts.com/{{ theme_tracking_hubspot_id }}.js"></script>
   <!-- End of HubSpot Embed Code -->
-  {% endif %}
-
-  {% if display_github %}
-  <!-- GitHub feedback section -->
-  <script>
-    var feedbackLoaded = false;
-        // check if feedback section is in viewport
-        function isInViewport(elem) {
-          var bounding = elem.getBoundingClientRect();
-          return (
-            bounding.top >= 0 &&
-            bounding.left >= 0 &&
-            bounding.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
-            bounding.right <= (window.innerWidth || document.documentElement.clientWidth)
-            );
-        };
-
-        var feedbackbox = document.querySelector('#cr-docs-feedback');
-        if (isInViewport(feedbackbox)) {
-          renderIssues();
-          feedbackLoaded = true;
-        }
-
-        $(window).scroll(function () {
-          if (!feedbackLoaded ){
-            if (isInViewport(feedbackbox)) {
-              renderIssues();
-              feedbackLoaded = true;
-            }
-          }
-        });
-
-        function renderIssues() {
-
-          function makeIssueHeader(open, closed) {
-            var html = "<div class='cr-docs-feedback-nav'><ul> \
-            <li><a id='issues-open' class='cr-fb-link cr-fb-active' title='View Open issues'>Open (";
-
-                      // if more than 30 issues, add "Last"
-                      if (open.length >= 30) { html += `Last `; }
-                      html += open.length + ")</a></li> \
-                      <li><a id='issues-closed' class='cr-fb-link' title='View Closed issues'>Closed (";
-                      if (closed.length >= 30) { html += `Last `; }
-                      html += closed.length + ")</a></li> \
-                      </ul></div>";
-
-                      return html;
-          };
-
-          function listIssues(issues, isClosed) {
-            var divId;
-            var display;
-            if (!isClosed) {
-              divId = "cr-docs-issues-open-list";
-              display = 'block';
-            } else {
-              divId = "cr-docs-issues-closed-list";
-              display = 'none';
-            }
-            var html = `<div style='display: ${display};' id='${divId}' class='cr-docs-feedback-issues'><ul>`;
-
-            // if no issues are found, post this
-            if (issues.length == 0) { html += `<li>Currently there is no feedback for this document.</li>` }
-
-              else {
-                issues.forEach((issue) => {
-                  html += `<li><div class='cr-docs-feedback-entry'><div class='cr-docs-feedback-title'><strong><a href='${issue.html_url}' rel='noopener' class='cr-docs-link' title='View issue on GitHub' target='blank'>${issue.title}</a></strong></div>`;
-
-                    // show PR if applicable
-                    if (issue.pull_request != undefined) {
-                      html += `<div class='cr-docs-feedback-pr'><svg viewBox='0 0 12 16' version='1.1' width='12' height='16' aria-hidden='true'><path fill-rule='evenodd' d='M11 11.28V5c-.03-.78-.34-1.47-.94-2.06C9.46 2.35 8.78 2.03 8 2H7V0L4 3l3 3V4h1c.27.02.48.11.69.31.21.2.3.42.31.69v6.28A1.993 1.993 0 0010 15a1.993 1.993 0 001-3.72zm-1 2.92c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zM4 3c0-1.11-.89-2-2-2a1.993 1.993 0 00-1 3.72v6.56A1.993 1.993 0 002 15a1.993 1.993 0 001-3.72V4.72c.59-.34 1-.98 1-1.72zm-.8 10c0 .66-.55 1.2-1.2 1.2-.65 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z'><title>Pull Request</title></path></svg></div>`;
-                    }
-                    // show # of comments
-                    if (issue.comments != 0) {
-                      html += `<div class='cr-docs-feedback-comments'><a href='${issue.html_url}' rel='noopener' class='cr-docs-link' title='View issue on GitHub' target='blank'><svg viewBox='0 0 16 16' version='1.1' width='16' height='16' aria-hidden='true'><path fill-rule='evenodd' d='M14 1H2c-.55 0-1 .45-1 1v8c0 .55.45 1 1 1h2v3.5L7.5 11H14c.55 0 1-.45 1-1V2c0-.55-.45-1-1-1zm0 9H7l-2 2v-2H2V2h12v8z'><title>Comment</title></path></svg> ${issue.comments}</a></div>`;
-                    }
-                    // show issue number + link to it
-                    html += `</div><div class='cr-docs-feedback-details'><a href='${issue.html_url}' rel='noopener' class='cr-docs-link' title='View issue on GitHub' target='blank'>#${issue.number}</a> `;
-
-                    var date = new Date(issue.created_at);
-
-                    const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
-                    var formatted_date = date.getDate() + " "
-                    + months[date.getMonth()] + " "
-                    + date.getFullYear();
-
-                    html += `opened on ${formatted_date} by <a href='${issue.user.html_url}' rel='noopener' class='cr-docs-link' title='View ${issue.user.login} on GitHub' `;
-                    html += ` target='blank'>${issue.user.login}</a></br>`;
-                    html += "</div></li>";
-                  });
-              }
-
-              html += "</ul></div>";
-              return html;
-            }
-
-            async function fetchIssues(url) {
-              const data = await fetch(url).then((response) => response.json());
-              return data;
-            }
-
-            const content = document.getElementById('cr-feedback-content');
-            content.innerHTML = '<p>Loading data...</p>';
-            fetchIssues("https://api.{{ github_host|default('github.com') }}/search/issues?q=repo:{{ github_user }}/{{ github_repo }}+label%3A\"area%3A+docs\"+\"{{ title|striptags|urlencode }}\"+\"{{ pagename|urlencode }}.html\"")
-                .then(function (issues) {
-                  const openIssues = issues.items.filter(x => x.state == 'open');
-                  const closedIssues = issues.items.filter(x => x.state == 'closed');
-                  var html = makeIssueHeader(openIssues, closedIssues);
-                  html += listIssues(openIssues);
-                  html += listIssues(closedIssues, true);
-                  content.innerHTML = html;
-                  const openButton = document.getElementById('issues-open');
-                  const closedButton = document.getElementById('issues-closed');
-                  const openList = document.getElementById('cr-docs-issues-open-list');
-                  const closedList = document.getElementById('cr-docs-issues-closed-list');
-                  openButton.addEventListener('click', function (e) {
-                    openButton.classList.add('cr-fb-active');
-                    closedButton.classList.remove('cr-fb-active');
-                    openList.style.display = 'block';
-                    closedList.style.display = 'none';
-                  });
-                  closedButton.addEventListener('click', function (e) {
-                    openButton.classList.remove('cr-fb-active');
-                    closedButton.classList.add('cr-fb-active');
-                    openList.style.display = 'none';
-                    closedList.style.display = 'block';
-                  });
-
-                {% if theme_tracking_segment_id %}
-                analytics.track('Feedback Opened');
-                {% endif %}
-                }).catch(function() {
-                // if rate limit exceeded, throw this error
-                content.innerHTML = '<p>Error loading data, limit exceeded. Please try again later.</p>';
-                {% if theme_tracking_segment_id %}
-                analytics.track('DOCS RATE LIMIT', {
-                  location: 'Center',
-                  text: 'Error loading data, limit exceeded. Please try again later.',
-                  category: 'Docs',
-                  type: 'Text',
-                  pageTitle: document.title
-               });
-               {% endif %}
-        });
-    }
-  </script>
   {% endif %}
 
   {% if pagename == "search" %}

--- a/src/crate/theme/rtd/crate/layout.html
+++ b/src/crate/theme/rtd/crate/layout.html
@@ -90,23 +90,11 @@
         </div>
         <div class="col-md-8 col-lg-9" role="main">
           <div class="wrapper-content-right">
+
             {%- if display_version %}
-            <div class="version-select-container">
-              <div data-delay="0" class="w-dropdown">
-                <div class="w-dropdown-toggle toggle">
-                  <div><a href="{{ pathto(master_doc) }}">v:{{ current_version }}</a></div>
-                  <div class="w-icon-dropdown-toggle toggle-icon"></div>
-                </div>
-                {%- if versions %}
-                <nav class="w-dropdown-list dropdown-list">
-                  {% for slug, url in versions %}
-                  <a href="https://crate.io/{{ theme_canonical_url_path|replace('en/latest/', '') }}{{ rtd_language }}/{{ slug }}/" class="w-dropdown-link">{{ slug }}</a>
-                  {% endfor %}
-                </nav>
-                {%- endif %}
-              </div>
-            </div>
+            {% include "version_chooser.html" %}
             {%- endif %}
+
             {% block body %}{% endblock %}
           </div>
 

--- a/src/crate/theme/rtd/crate/layout.html
+++ b/src/crate/theme/rtd/crate/layout.html
@@ -90,7 +90,7 @@
         </div>
         <div class="col-md-8 col-lg-9" role="main">
           <div class="wrapper-content-right">
-            {%- if current_version %}
+            {%- if display_version %}
             <div class="version-select-container">
               <div data-delay="0" class="w-dropdown">
                 <div class="w-dropdown-toggle toggle">

--- a/src/crate/theme/rtd/crate/static/css/crateio-ng.css
+++ b/src/crate/theme/rtd/crate/static/css/crateio-ng.css
@@ -1,0 +1,24 @@
+/* Version chooser component */
+
+.version-chooser-content {
+  position: absolute;
+}
+.version-chooser-content div.sd-summary-content {
+  position: fixed;
+  z-index: 150;
+  background: #fff;
+  border: 1px solid #ccc;
+}
+
+.version-chooser-container {
+  float: right;
+}
+.version-chooser-content {
+  position: absolute;
+}
+.version-chooser-title {
+  font-weight: unset !important;
+}
+.version-chooser-link {
+  color: #222222;
+}

--- a/src/crate/theme/rtd/crate/static/css/crateio.css
+++ b/src/crate/theme/rtd/crate/static/css/crateio.css
@@ -855,10 +855,6 @@ a.learn-more-link,
   padding: 10px 20px;
 }
 
-.version-select-container {
-  float: right;
-  text-align: right;
-}
 .view-on-github {
 }
 .view-on-github .fa-github:before {

--- a/src/crate/theme/rtd/crate/static/css/index.css
+++ b/src/crate/theme/rtd/crate/static/css/index.css
@@ -1,5 +1,6 @@
 @import "~normalize.css";
 @import "components.css";
 @import "crateio.css";
+@import "crateio-ng.css";
 @import "crateio-rtd.css";
 @import "custom.css";

--- a/src/crate/theme/rtd/crate/static/js/index.js
+++ b/src/crate/theme/rtd/crate/static/js/index.js
@@ -2,6 +2,7 @@ import "jquery";
 import * as Cookies from "js-cookie";
 import "sticky-sidebar";
 
+import "./util";
 import "./webflow";
 import "./crate";
 import "./custom";

--- a/src/crate/theme/rtd/crate/static/js/util.js
+++ b/src/crate/theme/rtd/crate/static/js/util.js
@@ -1,0 +1,9 @@
+window.isInViewport = function(elem) {
+    var bounding = elem.getBoundingClientRect();
+    return (
+        bounding.top >= 0 &&
+        bounding.left >= 0 &&
+        bounding.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
+        bounding.right <= (window.innerWidth || document.documentElement.clientWidth)
+    );
+}

--- a/src/crate/theme/rtd/crate/version_chooser.html
+++ b/src/crate/theme/rtd/crate/version_chooser.html
@@ -1,0 +1,17 @@
+<!-- Version chooser component -->
+
+<div class="version-select-container">
+  <div data-delay="0" class="w-dropdown">
+    <div class="w-dropdown-toggle toggle">
+      <div><a href="{{ pathto(master_doc) }}">v:{{ current_version }}</a></div>
+      <div class="w-icon-dropdown-toggle toggle-icon"></div>
+    </div>
+    {%- if versions %}
+    <nav class="w-dropdown-list dropdown-list">
+      {% for slug, url in versions %}
+      <a href="https://crate.io/{{ theme_canonical_url_path|replace('en/latest/', '') }}{{ rtd_language }}/{{ slug }}/" class="w-dropdown-link">{{ slug }}</a>
+      {% endfor %}
+    </nav>
+    {%- endif %}
+  </div>
+</div>

--- a/src/crate/theme/rtd/crate/version_chooser.html
+++ b/src/crate/theme/rtd/crate/version_chooser.html
@@ -1,17 +1,23 @@
 <!-- Version chooser component -->
 
-<div class="version-select-container">
-  <div data-delay="0" class="w-dropdown">
-    <div class="w-dropdown-toggle toggle">
+<div class="version-chooser-container">
+  <details class="sd-sphinx-override sd-dropdown sd-card sd-mb-3 version-chooser-content">  <!-- open="" -->
+    <summary class="sd-summary-title sd-card-header version-chooser-title">
       <div><a href="{{ pathto(master_doc) }}">v:{{ current_version }}</a></div>
-      <div class="w-icon-dropdown-toggle toggle-icon"></div>
-    </div>
-    {%- if versions %}
-    <nav class="w-dropdown-list dropdown-list">
+
+      <div class="sd-summary-down docutils">
+        <svg version="1.1" width="1.5em" height="1.5em" class="sd-octicon sd-octicon-chevron-down" viewBox="0 0 24 24" aria-hidden="true"><path fill-rule="evenodd" d="M5.22 8.72a.75.75 0 000 1.06l6.25 6.25a.75.75 0 001.06 0l6.25-6.25a.75.75 0 00-1.06-1.06L12 14.44 6.28 8.72a.75.75 0 00-1.06 0z"></path></svg>
+      </div>
+      <div class="sd-summary-up docutils">
+        <svg version="1.1" width="1.5em" height="1.5em" class="sd-octicon sd-octicon-chevron-up" viewBox="0 0 24 24" aria-hidden="true"><path fill-rule="evenodd" d="M18.78 15.28a.75.75 0 000-1.06l-6.25-6.25a.75.75 0 00-1.06 0l-6.25 6.25a.75.75 0 101.06 1.06L12 9.56l5.72 5.72a.75.75 0 001.06 0z"></path></svg>
+      </div>
+    </summary>
+    <div class="sd-summary-content sd-card-body docutils">
       {% for slug, url in versions %}
-      <a href="https://crate.io/{{ theme_canonical_url_path|replace('en/latest/', '') }}{{ rtd_language }}/{{ slug }}/" class="w-dropdown-link">{{ slug }}</a>
+      <p class="sd-card-text">
+        <a href="https://crate.io/{{ theme_canonical_url_path|replace('en/latest/', '') }}{{ rtd_language }}/{{ slug }}/" class="version-chooser-link">{{ slug }}</a>
+      </p>
       {% endfor %}
-    </nav>
-    {%- endif %}
-  </div>
+    </div>
+  </details>
 </div>


### PR DESCRIPTION
## About

Use separate files for defining the feedback component at the bottom of the page, and the version chooser at the top of the page.

## Details

It aims to set the stage for GH-385, which actually changes the page layout. This patch only moves code around, and starts building upon modern styling components, without changing the visual appearance too much.

## Preview

https://crate-docs-theme--384.org.readthedocs.build/en/384/

## References
- https://github.com/crate/crate-docs/pull/99 will make it easier to work on such refactorings, by also triggering automatic rebuilds on changes to HTML, CSS, and JS files.