### PR TITLE
Remove external links indicator

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Unreleased
 - Refactor GitHub feedback component to separate files
 - Migrate version chooser component to sphinx-design dropdown
 - Use compact variant of GitHub feedback component at the top of the page
+- Remove external links indicator
 
 
 2023/05/15 0.27.1

--- a/src/crate/theme/rtd/crate/static/css/custom.css
+++ b/src/crate/theme/rtd/crate/static/css/custom.css
@@ -1538,14 +1538,6 @@ ul#cr-search-results {
   }
 }
 
-/* external links indicator */
-#main-content .col-md-8 [href^="http"]:not([href*="https://crate.io"]):not([href*="go.cratedb.com"]):not([href*="cdn.crate.io"]):not([href*="wpengine.com"]):not([href^="#"]):not([href^="/"]):not(.image-reference):not(.cr-docs-link):not(.internal)
-{
-  background: url(../images/icon_link_external.svg) center left no-repeat;
-  padding-left: 20px;
-  margin-left: 2px;
-}
-
 /* glossary links indicator */
 a[href*="#gloss-"].internal {
   /* workaround as text-decoration cannot be overridden on child elements */


### PR DESCRIPTION
## About

The example at [^1] clearly shows why the external links indicator is annoying. This patch removes it.

![image](https://github.com/crate/crate-docs-theme/assets/453543/5630914e-9fb8-4cbf-803d-cb33f30a2ae0)

## Preview

See [^2].

![image](https://github.com/crate/crate-docs-theme/assets/453543/adcbf7b6-5160-4727-8d46-a954f86c88fb)


[^1]: https://crate-docs-theme.readthedocs.io/en/latest/rst/infocard.html#example-3
[^2]: https://crate-docs-theme--386.org.readthedocs.build/en/386/rst/infocard.html#example-3
