### PR TITLE
Improve visual appearance of admonition components

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ Unreleased
 - Migrate version chooser component to sphinx-design dropdown
 - Use compact variant of GitHub feedback component at the top of the page
 - Remove external links indicator
+- Improve visual appearance of admonition components
 
 
 2023/05/15 0.27.1

--- a/docs/admonitions.rst
+++ b/docs/admonitions.rst
@@ -1,18 +1,57 @@
-==============================
-Different kinds of admonitions
-==============================
+###########
+Admonitions
+###########
 
-Introduction
-============
+
+*****
+About
+*****
 
 Admonitions are visually set off from the rest of the content and have a
 colored background. To the left of admonition content paragraphs, there is an
 icon that represents the kind/type of the admonition.
 
-Samples
-=======
 
-.. _first-admonition:
+********
+Variants
+********
+
+There are two variants of admonitions.
+
+Regular
+=======
+Regular admonitions are very compact, and use a smaller font size. They can be
+used to convey more detailed information to the reader, even larger amounts of
+text, without taking too much screen space, and without obstructing the reading
+flow too much.
+
+.. NOTE::
+
+    Franz jagt im komplett verwahrlosten Taxi quer durch Bayern.
+
+Hero
+====
+On the other hand, `hero-/jumbotron-style`_ admonition components have a bolder
+visual appearance. They can be used for showcasing hero unit style content, and
+for calling extra attention to featured content or information. They are defined
+by adding a ``:class: hero`` option to the markup directive.
+
+.. NOTE::
+    :class: hero
+
+    Franz jagt im komplett verwahrlosten Taxi quer durch Bayern.
+
+
+.. _admonition-gallery:
+
+*******
+Gallery
+*******
+
+This section demonstrates all available admonition components, in both variants.
+
+Regular
+=======
 
 .. NOTE::
 
@@ -20,15 +59,11 @@ Samples
 
     This is a second paragraph.
 
-.. _second-admonition:
-
 .. TIP::
 
     This is the first paragraph of a *tip* admonition.
 
     This is a second paragraph.
-
-.. _more-admonitions:
 
 .. SEEALSO::
 
@@ -45,3 +80,44 @@ Samples
 .. DANGER::
 
     This is the first paragraph of a *danger* admonition.
+
+
+Hero
+====
+
+.. NOTE::
+    :class: hero
+
+    This is the first paragraph of a *note* admonition.
+
+    This is a second paragraph.
+
+.. TIP::
+    :class: hero
+
+    This is the first paragraph of a *tip* admonition.
+
+    This is a second paragraph.
+
+.. SEEALSO::
+    :class: hero
+
+    This is the first paragraph of a *seealso* admonition.
+
+.. CAUTION::
+    :class: hero
+
+    This is the first paragraph of a *caution* admonition.
+
+.. WARNING::
+    :class: hero
+
+    This is the first paragraph of a *warning* admonition.
+
+.. DANGER::
+    :class: hero
+
+    This is the first paragraph of a *danger* admonition.
+
+
+.. _hero-/jumbotron-style: https://getbootstrap.com/docs/4.1/components/jumbotron/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -85,7 +85,7 @@ How to use this documentation:
 
 - Verify that each page element displays correctly. Some page elements identify
   themselves (e.g., the :ref:`index`) and some elements describe how they ought
-  to appear (e.g., the :ref:`first admonition <first-admonition>`).
+  to appear (e.g., the :ref:`admonition gallery <admonition-gallery>`).
 
 How to improve this documentation:
 

--- a/src/crate/theme/rtd/crate/static/css/crateio-rtd.css
+++ b/src/crate/theme/rtd/crate/static/css/crateio-rtd.css
@@ -28,60 +28,90 @@ blockquote p:last-child {
     margin-bottom: 0;
 }
 
-/** admonitions **/
 
-div.admonition p {
+
+/** Admonitions: Regular style **/
+div.admonition:not(.hero) p {
+    padding: unset;
+    margin: unset;
+}
+div.admonition:not(.hero) {
+    padding-left: 3em;
+    font-size: smaller;
+    background-position: top 0.75em left 1em;
+    background-size: 1.25em;
+    border-left-width: 2px;
+}
+
+
+/** Admonitions: Hero style **/
+div.admonition.hero {
+    padding: 15px 15px 15px 95px;
+    margin: 20px 0;
+    background-position: top 25px left 25px;
+    background-size: 3em;
+    border-left-width: 4px;
+}
+div.admonition.hero p {
     padding: 10px 0;
     margin: 0;
 }
-
-div.admonition {
-    padding: 15px 15px 15px 95px;
-    margin: 20px 0;
-    border-left: 0;
-    background-position: top 25px left 25px !important;
+div.admonition.hero a {
+  color: black;
+  text-decoration: underline;
 }
-
-div.admonition ul {
+div.admonition.hero ul {
     padding-top: 10px;
     padding-bottom: 10px;
     margin: 0;
+}
+div.admonition.hero ul.simple p {
+  padding: 0;
+}
+div.admonition.hero ul.open p {
+  padding: 0 0 10px 0;
+}
+
+
+/** Admonitions: General **/
+div.admonition {
+    border-left-style: solid;
 }
 
 div.note {
     background: url(../images/admonition/icon-docs-note.svg) no-repeat;
     background-color: #eefafe;
-    border-left: 4px solid #009DC7;
+    border-color: #009DC7;
 }
 
 div.seealso {
     background: url(../images/admonition/icon-docs-seealso.svg) no-repeat;
     background-color: #f4f4f4;
-    border-left: 4px solid #999999;
+    border-color: #999999;
 }
 
 div.tip {
     background: url(../images/admonition/icon-docs-tip.svg) no-repeat;
     background-color: #eefafe;
-    border-left: 4px solid #009DC7;
+    border-color: #009DC7;
 }
 
 div.caution {
     background: url(../images/admonition/icon-docs-caution.svg) no-repeat;
     background-color: #fff2ed;
-    border-left: 4px solid #ff814d;
+    border-color: #ff814d;
 }
 
 div.warning {
     background: url(../images/admonition/icon-docs-warning.svg) no-repeat;
     background-color: #fdeeee;
-    border-left: 4px solid #ec4d4d;
+    border-color: #ec4d4d;
 }
 
 div.danger {
     background: url(../images/admonition/icon-docs-danger.svg) no-repeat;
     background-color: #fdeeee;
-    border-left: 4px solid #ec4d4d;
+    border-color: #ec4d4d;
 }
 
 .note .admonition-title,

--- a/src/crate/theme/rtd/crate/static/css/crateio.css
+++ b/src/crate/theme/rtd/crate/static/css/crateio.css
@@ -838,22 +838,6 @@ a.learn-more-link,
   margin: 0px;
 }
 
-.admonition {
-  margin-top: 16px !important;
-  margin-bottom: 16px !important;
-  padding: 7px;
-}
-
-.admonition p {
-  margin-bottom: 0px;
-  padding: 10px 20px;
-}
-
-.admonition-title {
-  display: block;
-  margin: 0px;
-  padding: 10px 20px;
-}
 
 .view-on-github {
 }

--- a/src/crate/theme/rtd/crate/static/css/custom.css
+++ b/src/crate/theme/rtd/crate/static/css/custom.css
@@ -786,11 +786,6 @@ body .mm-menu .navbar-nav {
   margin-left: 0.3em;
 }
 
-.admonition a {
-  color: black;
-  text-decoration: underline;
-}
-
 table.docutils {
   margin-bottom: 16px;
 }
@@ -1610,14 +1605,6 @@ footer .footer-listitem-new:first-child a {
   .cr-navtoggle.cr-navtoggle-mid {
     margin: 8px 0;
   }
-}
-
-div.admonition ul.simple p {
-  padding: 0;
-}
-
-div.admonition ul.open p {
-  padding: 0 0 10px 0;
 }
 
 /**


### PR DESCRIPTION
## About

Another reason why the look&feel of our documentation is a bit clunky sometimes, are the very bold/large/wide appearances of the admonition components, obstructing the reading flow [^1].

In order to save screen space for main content, this patch aims to tame them a bit, and render them in a more compact style, similar to how those are [originally rendered](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#paragraph-level-markup), and also on [other themes](https://pradyunsg.me/furo/reference/admonitions/).

![image](https://github.com/crate/crate-docs-theme/assets/453543/61bf7898-2821-4479-b93c-c61054b65a67)

## Details

However, we retain the [hero-/jumbotron-style](https://getbootstrap.com/docs/4.1/components/jumbotron/), as it is valuable for calling extra attention to featured content or information, which may have been the original intention of their bold design. Such admonitions can now be written by adding a `:class: hero` option to the markup directive.

![image](https://github.com/crate/crate-docs-theme/assets/453543/da08b76f-81df-4580-942a-bc54c88b5b7d)


## Preview

https://crate-docs-theme--387.org.readthedocs.build/en/387/admonitions.html


[^1]: https://crate.io/docs/crate/clients-tools/ is a rather extreme example here. Other examples have been improved on layout matters already, by just removing those wide admonitions altogether. However, this was not a solution to the problem, just a workaround.
