### PR TITLE
Install consolidated Cloud Docs, and edit primary navigation section in left sidebar

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,11 @@ Unreleased
 - Improve visual appearance of admonition components
 - Add new ``cloud-docs`` documentation project
 
+- Edit primary navigation in left sidebar.
+
+  - "CrateDB Cloud" documentation has been bundled into a single repository, now
+    located at ``/docs/cloud``.
+
 
 2023/05/15 0.27.1
 -----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,12 @@ Unreleased
   - Rename ``Install CrateDB`` to ``Install``, and ``Reference`` to ``CrateDB Reference``
   - Improve appearance of bottom section
 
+- Consolidated Cloud Docs: Adjust intersphinx root references
+
+  - Those project references have been dissolved:
+    ``cloud-reference``, ``cloud-tutorials``, and ``cloud-howtos``
+  - The new canonical intersphinx project reference is just ``cloud``
+
 
 2023/08/01 0.28.2
 -----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,7 @@ Unreleased
 
   - "CrateDB Cloud" documentation has been bundled into a single repository, now
     located at ``/docs/cloud``.
+  - Two more links to "Examples and stacks" and "Community", have been added.
 
 
 2023/05/15 0.27.1

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,14 @@ CHANGES
 Unreleased
 ----------
 
+- Edit primary navigation in left sidebar
+
+  - "CrateDB Cloud" documentation has been bundled into a single repository, now
+    located at ``/docs/cloud``
+  - Add link to "Community" and "Integration tutorials"
+  - Rename ``Install CrateDB`` to ``Install``, and ``Reference`` to ``CrateDB Reference``
+  - Improve appearance of bottom section
+
 
 2023/08/01 0.28.2
 -----------------
@@ -32,13 +40,6 @@ Unreleased
 - Remove external links indicator
 - Improve visual appearance of admonition components
 - Add new ``cloud-docs`` documentation project
-- Edit primary navigation in left sidebar
-
-  - "CrateDB Cloud" documentation has been bundled into a single repository, now
-    located at ``/docs/cloud``
-  - Add link to "Community" and "Integration tutorials"
-  - Rename ``Install CrateDB`` to ``Install``, and ``Reference`` to ``CrateDB Reference``
-  - Improve appearance of bottom section
 
 
 2023/05/15 0.27.1

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,13 +32,13 @@ Unreleased
 - Remove external links indicator
 - Improve visual appearance of admonition components
 - Add new ``cloud-docs`` documentation project
-
-- Edit primary navigation in left sidebar.
+- Edit primary navigation in left sidebar
 
   - "CrateDB Cloud" documentation has been bundled into a single repository, now
     located at ``/docs/cloud``
-  - Add link to "Community"
+  - Add link to "Community" and "Integration tutorials"
   - Rename ``Install CrateDB`` to ``Install``, and ``Reference`` to ``CrateDB Reference``
+  - Improve appearance of bottom section
 
 
 2023/05/15 0.27.1

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,8 +36,9 @@ Unreleased
 - Edit primary navigation in left sidebar.
 
   - "CrateDB Cloud" documentation has been bundled into a single repository, now
-    located at ``/docs/cloud``.
-  - Two more links to "Examples and stacks" and "Community", have been added.
+    located at ``/docs/cloud``
+  - Add link to "Community"
+  - Rename ``Install CrateDB`` to ``Install``, and ``Reference`` to ``CrateDB Reference``
 
 
 2023/05/15 0.27.1

--- a/docs/links.rst
+++ b/docs/links.rst
@@ -38,9 +38,9 @@ CrateDB clients
 CrateDB Cloud
 -------------
 
-- :ref:`cloud-reference:index`
-- :ref:`cloud-tutorials:index`
-- :ref:`cloud-howtos:index`
+- :ref:`cloud:cloud-reference-index`
+- :ref:`cloud:cloud-tutorials-index`
+- :ref:`cloud:cloud-howtos-index`
 - :ref:`cloud-cli:index`
 
 

--- a/src/crate/theme/rtd/conf/__init__.py
+++ b/src/crate/theme/rtd/conf/__init__.py
@@ -116,9 +116,7 @@ intersphinx_mapping = {
     'crate-python': ('https://crate.io/docs/python/en/latest/', None),
 
     # CrateDB Cloud
-    'cloud-reference': ('https://crate.io/docs/cloud/reference/en/latest/', None),
-    'cloud-tutorials': ('https://crate.io/docs/cloud/tutorials/en/latest/', None),
-    'cloud-howtos': ('https://crate.io/docs/cloud/howtos/en/latest/', None),
+    'cloud': ('https://crate.io/docs/cloud/en/latest/', None),
     'cloud-cli': ('https://crate.io/docs/cloud/cli/en/latest/', None),
 
     # Misc

--- a/src/crate/theme/rtd/crate/sidebartoc.html
+++ b/src/crate/theme/rtd/crate/sidebartoc.html
@@ -108,7 +108,9 @@
   <li class="navleft-item"><a href="/docs/npgsql/">.NET Npgsql</a></li>
   {% endif %}
 
-  <li class="navleft-item border-top"><a href="https://github.com/crate/crate-sample-apps">Sample Applications</a></li>
+  <li class="navleft-item border-top"><a href="https://github.com/crate/cratedb-examples">Examples and stacks</a></li>
+
+  <li class="navleft-item"><a href="https://github.com/crate/crate-sample-apps">Sample applications</a></li>
 
   {% if project == 'Doing Docs' %}
   <li class="current">
@@ -118,6 +120,7 @@
   {% endif %}
 
   <li class="navleft-item"><a href="/support/">Support</a></li>
+  <li class="navleft-item"><a href="https://community.crate.io/">Community</a></li>
 
   {% endif %}
 

--- a/src/crate/theme/rtd/crate/sidebartoc.html
+++ b/src/crate/theme/rtd/crate/sidebartoc.html
@@ -78,8 +78,8 @@
   <!-- Section D. -->
   <li class="navleft-item border-top"><a href="/support/">Support</a></li>
   <li class="navleft-item"><a href="https://community.crate.io/">Community</a></li>
-  <li class="navleft-item"><a href="https://community.crate.io/t/overview-of-cratedb-integration-tutorials/1015">Integration tutorials</a></li>
-  <li class="navleft-item"><a href="https://github.com/crate/crate-sample-apps">Sample applications</a></li>
+  <li class="navleft-item"><a href="https://community.crate.io/t/overview-of-cratedb-integration-tutorials/1015">Integration Tutorials</a></li>
+  <li class="navleft-item"><a href="https://github.com/crate/crate-sample-apps">Sample Applications</a></li>
 
   {% if project == 'Doing Docs' %}
   <li class="current">

--- a/src/crate/theme/rtd/crate/sidebartoc.html
+++ b/src/crate/theme/rtd/crate/sidebartoc.html
@@ -11,11 +11,11 @@
 
   {% if project == 'CrateDB: Tutorials' %}
     <li class="current">
-      <a class="current-active" href="{{ pathto(master_doc) }}">Install CrateDB</a>
+      <a class="current-active" href="{{ pathto(master_doc) }}">Install</a>
       {{ toctree(maxdepth=3|toint, collapse=True, includehidden=theme_globaltoc_includehidden|tobool) }}
     </li>
   {% else %}
-    <li class="navleft-item"><a href="/docs/crate/tutorials/">Install CrateDB</a></li>
+    <li class="navleft-item"><a href="/docs/crate/tutorials/">Install</a></li>
   {% endif %}
   {% if project == 'CrateDB: How-Tos' %}
     <li class="current">
@@ -27,11 +27,11 @@
   {% endif %}
   {% if project == 'CrateDB: Reference' %}
     <li class="current">
-      <a class="current-active" href="{{ pathto(master_doc) }}">Reference</a>
+      <a class="current-active" href="{{ pathto(master_doc) }}">CrateDB Reference</a>
       {{ toctree(maxdepth=3|toint, collapse=True, includehidden=theme_globaltoc_includehidden|tobool) }}
     </li>
   {% else %}
-    <li class="navleft-item"><a href="/docs/crate/reference/">Reference</a></li>
+    <li class="navleft-item"><a href="/docs/crate/reference/">CrateDB Reference</a></li>
   {% endif %}
   {% if project == 'CrateDB Cloud' %}
     <li class="current">
@@ -107,8 +107,6 @@
   {% else %}
   <li class="navleft-item"><a href="/docs/npgsql/">.NET Npgsql</a></li>
   {% endif %}
-
-  <li class="navleft-item border-top"><a href="https://github.com/crate/cratedb-examples">Examples and stacks</a></li>
 
   <li class="navleft-item"><a href="https://github.com/crate/crate-sample-apps">Sample applications</a></li>
 

--- a/src/crate/theme/rtd/crate/sidebartoc.html
+++ b/src/crate/theme/rtd/crate/sidebartoc.html
@@ -75,49 +75,6 @@
     <li class="navleft-item"><a href="/docs/crate/clients-tools/">Clients, Drivers, and Tools</a></li>
   {% endif %}
 
-
-  <!-- Section C. -->
-  {% if project == 'CrateDB JDBC' %}
-  <li class="current border-top">
-    <a class="current-active" href="{{ pathto(master_doc) }}">JDBC</a>
-    {{ toctree(maxdepth=1|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
-  </li>
-  {% else %}
-  <li class="navleft-item border-top"><a href="/docs/jdbc/">JDBC</a></li>
-  {% endif %}
-  {% if project == 'CrateDB DBAL' %}
-  <li class="current">
-    <a class="current-active" href="{{ pathto(master_doc) }}">PHP DBAL</a>
-    {{ toctree(maxdepth=1|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
-  </li>
-  {% else %}
-  <li class="navleft-item"><a href="/docs/dbal/">PHP DBAL</a></li>
-  {% endif %}
-  {% if project == 'CrateDB PDO' %}
-  <li class="current">
-    <a class="current-active" href="{{ pathto(master_doc) }}">PHP PDO</a>
-    {{ toctree(maxdepth=1|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
-  </li>
-  {% else %}
-  <li class="navleft-item"><a href="/docs/pdo/">PHP PDO</a></li>
-  {% endif %}
-  {% if project == 'CrateDB Python' %}
-  <li class="current">
-    <a class="current-active" href="{{ pathto(master_doc) }}">Python</a>
-    {{ toctree(maxdepth=1|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
-  </li>
-  {% else %}
-  <li class="navleft-item"><a href="/docs/python/">Python</a></li>
-  {% endif %}
-  {% if project == 'CrateDB Npgsql' %}
-  <li class="current">
-    <a class="current-active" href="{{ pathto(master_doc) }}">.NET Npgsql</a>
-    {{ toctree(maxdepth=1|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
-  </li>
-  {% else %}
-  <li class="navleft-item"><a href="/docs/npgsql/">.NET Npgsql</a></li>
-  {% endif %}
-
   <!-- Section D. -->
   <li class="navleft-item border-top"><a href="/support/">Support</a></li>
   <li class="navleft-item"><a href="https://community.crate.io/">Community</a></li>

--- a/src/crate/theme/rtd/crate/sidebartoc.html
+++ b/src/crate/theme/rtd/crate/sidebartoc.html
@@ -108,6 +108,9 @@
   <li class="navleft-item"><a href="/docs/npgsql/">.NET Npgsql</a></li>
   {% endif %}
 
+  <li class="navleft-item border-top"><a href="/support/">Support</a></li>
+  <li class="navleft-item"><a href="https://community.crate.io/">Community</a></li>
+  <li class="navleft-item"><a href="https://community.crate.io/t/overview-of-cratedb-integration-tutorials/1015">Integration tutorials</a></li>
   <li class="navleft-item"><a href="https://github.com/crate/crate-sample-apps">Sample applications</a></li>
 
   {% if project == 'Doing Docs' %}
@@ -116,9 +119,6 @@
     {{ toctree(maxdepth=2|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
   </li>
   {% endif %}
-
-  <li class="navleft-item"><a href="/support/">Support</a></li>
-  <li class="navleft-item"><a href="https://community.crate.io/">Community</a></li>
 
   {% endif %}
 

--- a/src/crate/theme/rtd/crate/sidebartoc.html
+++ b/src/crate/theme/rtd/crate/sidebartoc.html
@@ -9,30 +9,7 @@
 
   {% else %}
 
-  {% if project == 'CrateDB: Tutorials' %}
-    <li class="current">
-      <a class="current-active" href="{{ pathto(master_doc) }}">Install</a>
-      {{ toctree(maxdepth=3|toint, collapse=True, includehidden=theme_globaltoc_includehidden|tobool) }}
-    </li>
-  {% else %}
-    <li class="navleft-item"><a href="/docs/crate/tutorials/">Install</a></li>
-  {% endif %}
-  {% if project == 'CrateDB: How-Tos' %}
-    <li class="current">
-      <a class="current-active" href="{{ pathto(master_doc) }}">CrateDB</a>
-      {{ toctree(maxdepth=3|toint, collapse=True, includehidden=theme_globaltoc_includehidden|tobool) }}
-    </li>
-  {% else %}
-    <li class="navleft-item"><a href="/docs/crate/howtos/">CrateDB</a></li>
-  {% endif %}
-  {% if project == 'CrateDB: Reference' %}
-    <li class="current">
-      <a class="current-active" href="{{ pathto(master_doc) }}">CrateDB Reference</a>
-      {{ toctree(maxdepth=3|toint, collapse=True, includehidden=theme_globaltoc_includehidden|tobool) }}
-    </li>
-  {% else %}
-    <li class="navleft-item"><a href="/docs/crate/reference/">CrateDB Reference</a></li>
-  {% endif %}
+  <!-- Section A. -->
   {% if project == 'CrateDB Cloud' %}
     <li class="current">
       <a class="current-active" href="{{ pathto(master_doc) }}">CrateDB Cloud</a>
@@ -41,6 +18,36 @@
   {% else %}
     <li class="navleft-item"><a href="/docs/cloud/">CrateDB Cloud</a></li>
   {% endif %}
+
+  {% if project == 'CrateDB: Tutorials' %}
+    <li class="current">
+      <a class="current-active" href="{{ pathto(master_doc) }}">Self-Managed</a>
+      {{ toctree(maxdepth=3|toint, collapse=True, includehidden=theme_globaltoc_includehidden|tobool) }}
+    </li>
+  {% else %}
+    <li class="navleft-item"><a href="/docs/crate/tutorials/">Self-Managed</a></li>
+  {% endif %}
+
+  {% if project == 'CrateDB: How-Tos' %}
+    <li class="current">
+      <a class="current-active" href="{{ pathto(master_doc) }}">Getting Started</a>
+      {{ toctree(maxdepth=3|toint, collapse=True, includehidden=theme_globaltoc_includehidden|tobool) }}
+    </li>
+  {% else %}
+    <li class="navleft-item"><a href="/docs/crate/howtos/">Getting Started</a></li>
+  {% endif %}
+
+  {% if project == 'CrateDB: Reference' %}
+    <li class="current">
+      <a class="current-active" href="{{ pathto(master_doc) }}">Reference Manual</a>
+      {{ toctree(maxdepth=3|toint, collapse=True, includehidden=theme_globaltoc_includehidden|tobool) }}
+    </li>
+  {% else %}
+    <li class="navleft-item"><a href="/docs/crate/reference/">Reference Manual</a></li>
+  {% endif %}
+
+
+  <!-- Section B. -->
   {% if project == 'CrateDB: Clients and Tools' %}
     <li class="current border-top">
       <a class="current-active" href="{{ pathto(master_doc) }}">Clients and Tools</a>

--- a/src/crate/theme/rtd/crate/sidebartoc.html
+++ b/src/crate/theme/rtd/crate/sidebartoc.html
@@ -33,13 +33,21 @@
   {% else %}
     <li class="navleft-item"><a href="/docs/crate/reference/">Reference</a></li>
   {% endif %}
-  {% if project == 'CrateDB: Clients and Tools' %}
+  {% if project == 'CrateDB Cloud' %}
     <li class="current">
+      <a class="current-active" href="{{ pathto(master_doc) }}">CrateDB Cloud</a>
+      {{ toctree(maxdepth=3|toint, collapse=True, includehidden=theme_globaltoc_includehidden|tobool) }}
+    </li>
+  {% else %}
+    <li class="navleft-item"><a href="/docs/cloud/">CrateDB Cloud</a></li>
+  {% endif %}
+  {% if project == 'CrateDB: Clients and Tools' %}
+    <li class="current border-top">
       <a class="current-active" href="{{ pathto(master_doc) }}">Clients and Tools</a>
       {{ toctree(maxdepth=3|toint, collapse=True, includehidden=theme_globaltoc_includehidden|tobool) }}
     </li>
   {% else %}
-    <li class="navleft-item"><a href="/docs/crate/clients-tools/">Clients and Tools</a></li>
+    <li class="navleft-item border-top"><a href="/docs/crate/clients-tools/">Clients and Tools</a></li>
   {% endif %}
 
   {% if project == 'CrateDB: Admin UI' %}
@@ -58,42 +66,6 @@
   {% else %}
   <li class="navleft-item"><a href="/docs/crate/crash/">Crash CLI</a></li>
   {% endif %}
-
-  <li class="navleft-item">CrateDB Cloud</li>
-  <ul>
-    {% if project == 'CrateDB Cloud: Tutorials' %}
-      <li class="current">
-        <a class="current-active" href="{{ pathto(master_doc) }}">Tutorials</a>
-        {{ toctree(maxdepth=2|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
-      </li>
-    {% else %}
-      <li class="navleft-item"><a href="/docs/cloud/tutorials/">Tutorials</a></li>
-    {% endif %}
-    {% if project == 'CrateDB Cloud: How-Tos' %}
-      <li class="current">
-        <a class="current-active" href="{{ pathto(master_doc) }}">How-To Guides</a>
-        {{ toctree(maxdepth=1|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
-      </li>
-    {% else %}
-      <li class="navleft-item"><a href="/docs/cloud/howtos/">How-To Guides</a></li>
-    {% endif %}
-    {% if project == 'CrateDB Cloud: Reference' %}
-      <li class="current">
-        <a class="current-active" href="{{ pathto(master_doc) }}">Reference</a>
-        {{ toctree(maxdepth=1|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
-      </li>
-    {% else %}
-      <li class="navleft-item"><a href="/docs/cloud/reference/">Reference</a></li>
-    {% endif %}
-    {% if project == 'CrateDB Cloud: Croud CLI' %}
-      <li class="current">
-        <a class="current-active" href="{{ pathto(master_doc) }}">Croud CLI</a>
-        {{ toctree(maxdepth=2|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
-      </li>
-    {% else %}
-      <li class="navleft-item"><a href="/docs/cloud/cli/">Croud CLI</a></li>
-    {% endif %}
-  </ul>
 
   {% if project == 'CrateDB JDBC' %}
   <li class="current border-top">

--- a/src/crate/theme/rtd/crate/sidebartoc.html
+++ b/src/crate/theme/rtd/crate/sidebartoc.html
@@ -68,11 +68,11 @@
 
   {% if project == 'CrateDB: Clients and Tools' %}
     <li class="current">
-      <a class="current-active" href="{{ pathto(master_doc) }}">Clients, Drivers, and Tools</a>
+      <a class="current-active" href="{{ pathto(master_doc) }}">Drivers and Integrations</a>
       {{ toctree(maxdepth=3|toint, collapse=True, includehidden=theme_globaltoc_includehidden|tobool) }}
     </li>
   {% else %}
-    <li class="navleft-item"><a href="/docs/crate/clients-tools/">Clients, Drivers, and Tools</a></li>
+    <li class="navleft-item"><a href="/docs/crate/clients-tools/">Drivers and Integrations</a></li>
   {% endif %}
 
   <!-- Section D. -->

--- a/src/crate/theme/rtd/crate/sidebartoc.html
+++ b/src/crate/theme/rtd/crate/sidebartoc.html
@@ -48,23 +48,15 @@
 
 
   <!-- Section B. -->
-  {% if project == 'CrateDB: Clients and Tools' %}
-    <li class="current border-top">
-      <a class="current-active" href="{{ pathto(master_doc) }}">Clients and Tools</a>
-      {{ toctree(maxdepth=3|toint, collapse=True, includehidden=theme_globaltoc_includehidden|tobool) }}
-    </li>
-  {% else %}
-    <li class="navleft-item border-top"><a href="/docs/crate/clients-tools/">Clients and Tools</a></li>
-  {% endif %}
-
   {% if project == 'CrateDB: Admin UI' %}
-  <li class="current">
+  <li class="current border-top">
     <a class="current-active" href="{{ pathto(master_doc) }}">Admin UI</a>
     {{ toctree(maxdepth=1|toint, collapse=True, includehidden=theme_globaltoc_includehidden|tobool) }}
   </li>
   {% else %}
-  <li class="navleft-item"><a href="/docs/crate/admin-ui/">Admin UI</a></li>
+  <li class="navleft-item border-top"><a href="/docs/crate/admin-ui/">Admin UI</a></li>
   {% endif %}
+
   {% if project == 'CrateDB: Crash CLI' %}
   <li class="current">
     <a class="current-active" href="{{ pathto(master_doc) }}">Crash CLI</a>
@@ -74,6 +66,17 @@
   <li class="navleft-item"><a href="/docs/crate/crash/">Crash CLI</a></li>
   {% endif %}
 
+  {% if project == 'CrateDB: Clients and Tools' %}
+    <li class="current">
+      <a class="current-active" href="{{ pathto(master_doc) }}">Clients, Drivers, and Tools</a>
+      {{ toctree(maxdepth=3|toint, collapse=True, includehidden=theme_globaltoc_includehidden|tobool) }}
+    </li>
+  {% else %}
+    <li class="navleft-item"><a href="/docs/crate/clients-tools/">Clients, Drivers, and Tools</a></li>
+  {% endif %}
+
+
+  <!-- Section C. -->
   {% if project == 'CrateDB JDBC' %}
   <li class="current border-top">
     <a class="current-active" href="{{ pathto(master_doc) }}">JDBC</a>
@@ -115,6 +118,7 @@
   <li class="navleft-item"><a href="/docs/npgsql/">.NET Npgsql</a></li>
   {% endif %}
 
+  <!-- Section D. -->
   <li class="navleft-item border-top"><a href="/support/">Support</a></li>
   <li class="navleft-item"><a href="https://community.crate.io/">Community</a></li>
   <li class="navleft-item"><a href="https://community.crate.io/t/overview-of-cratedb-integration-tutorials/1015">Integration tutorials</a></li>


### PR DESCRIPTION
## About

This adjusts a few sections of the primary navigation component.

## Details

- The CrateDB Cloud documentation has been refactored into the consolidated [cloud-docs](https://github.com/crate/cloud-docs) repository.
- While integrating it, move `CrateDB Cloud` menu item up [^1].
- Rename link label `Install CrateDB` to `Self-Managed`.
- Rename link label `CrateDB` to `Getting started`.
- Rename link label `Reference` to `Reference Manual`.
- Dissolve section C, listing individual drivers. This section has been reworked within the `Clients, Drivers, and Tools` section, and is much better presented now.
- Add two more links to bottom section D: `Community`, and `Integration Tutorials`.

## Preview

https://crate-docs-theme--391.org.readthedocs.build/en/391/

## Screenshots

A few iterations, from left to right.

![image](https://github.com/crate/crate-docs-theme/assets/453543/735c5339-a3a1-4efa-92a4-2f60fb78a250) ![image](https://github.com/crate/crate-docs-theme/assets/453543/d289f37c-2c93-435a-92c2-46d9c72d16f3) ![image](https://github.com/crate/crate-docs-theme/assets/453543/884882a3-051b-43fa-a916-8799cb6e38a7)

## Outlook

With GH-390, we will have another chance to overhaul the primary navigation section more thoroughly.

[^1]: ~~Under the hood, the `cloud-docs` repository will be linked into the documentation tree on behalf of a new project "CrateDB Services" instead of "CrateDB Cloud" (see `services.py`), in order to reflect it can be the home for more details beyond running a managed instance of CrateDB Database on cloud resources. This change is not reflected within the link labels yet, as it is only about plumbing right now, so that the new consolidated documentation repository is able to carry the weight of all future product ideas in this area.~~