### PR TITLE
Add new `cloud-docs` documentation project

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ Unreleased
 - Use compact variant of GitHub feedback component at the top of the page
 - Remove external links indicator
 - Improve visual appearance of admonition components
+- Add new ``cloud-docs`` documentation project
 
 
 2023/05/15 0.27.1

--- a/src/crate/theme/rtd/conf/cloud.py
+++ b/src/crate/theme/rtd/conf/cloud.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8; -*-
+#
+# Licensed to Crate (https://crate.io) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  Crate licenses
+# this file to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# However, if you have executed another commercial license agreement
+# with Crate these terms will supersede the license and you may use the
+# software solely pursuant to the terms of the relevant commercial agreement.
+
+
+from crate.theme.rtd.conf import *
+
+# If you update the `project` value here, you must update it in the
+# `src/crate/theme/rtd/crate/sidebartoc.html` file or else Sphinx will not
+# expand the sidebar TOC for this project.
+project = "CrateDB Cloud"
+html_title = project
+
+url_path = "docs/cloud"
+
+# For sitemap extension
+html_baseurl = "https://crate.io/%s/" % url_path
+
+# For rel="canonical" links
+html_theme_options.update(
+    {
+        "canonical_url_path": "%s/en/latest/" % url_path,
+    }
+)
+
+ogp_site_url = html_baseurl


### PR DESCRIPTION
## About

CrateDB Cloud documentation has been refactored into a [consolidated repository](https://github.com/crate/cloud-docs) by @matkuliak, thanks. This patch adds a corresponding slot to the backbone.

## Details

Because of chicken-egg problems, this needs to be separated from GH-391, and properly released before, to make downstream projects follow in lock-step.
