### PR TITLE
Adjust footer navigation after web site update

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ CHANGES
 Unreleased
 ----------
 
+- Adjust footer navigation after web site update. Thanks, @msbt.
+
 
 2023/07/29 0.28.1
 -----------------

--- a/src/crate/theme/rtd/crate/footer.html
+++ b/src/crate/theme/rtd/crate/footer.html
@@ -1,10 +1,31 @@
+<div class="footer-subscription cr-nojs-hide">
+  <div class="content-wrapper container">
+    <div class="row">
+      <div class="col-md-3">
+        <h4>Subscribe to the CrateDB Newsletter now</h4>
+      </div>
+      <div class="col-md-9">
+        <div class="footer-subs-form">
+          <!--[if lte IE 8]>
+          <script charset="utf-8" type="text/javascript" src="//js.hsforms.net/forms/v2-legacy.js"></script>
+        <![endif]-->
+          <script charset="utf-8" type="text/javascript" src="//js.hsforms.net/forms/v2.js"></script>
+          <script>
+            hbspt.forms.create({
+              region: "na1",
+              portalId: "19927462",
+              formId: "76d1441f-eef8-4e8e-950d-9b66bf24bd8e"
+            });
+          </script>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
 <footer class="footer">
   <div class="container">
     <div class="w-clearfix">
-      
-      {% if project == 'SQL 99' %}
       <div class="w-row mobileAlign">
-        
         <div class="row">
           <div class="col-md-4 text-md-center">
             <a class="w-inline-block" href="/" title="crate.io">
@@ -15,13 +36,10 @@
             <div class="cr-docs-footer-menu">
               <ul>
                 <li>
-                  <a href="/about/">About</a>
+                  <a href="/legal/imprint">Imprint</a>
                 </li>
                 <li>
-                  <a href="/contact/">Imprint</a>
-                </li>
-                <li>
-                  <a href="/legal/imprint/">Contract</a>
+                  <a href="/contact">Contact</a>
                 </li>
                 <li>
                   <a href="/legal/">Legal</a>
@@ -53,165 +71,6 @@
           </div>
         </div>
       </div>
-      {% else %}
-      
-      <div class="w-row mobileAlign">
-        <esi:remove>
-        <div class="row-fluid">
-          <div class="span12">
-            <div class="row-fluid footer-widget">
-              <div id="hs_cos_wrapper_module_16142721378942" class="hs_cos_wrapper hs_cos_wrapper_widget hs_cos_wrapper_type_module">
-                <div class="span2 footer-widget-content">
-                  <h3 class="footer-menu-title">Product</h3>
-                  <div id="hs_cos_wrapper_module_16142721378942_" class="hs_cos_wrapper hs_cos_wrapper_widget hs_cos_wrapper_type_inline_rich_text"><ul>
-                    <li><a class="nav-link" href="/products/cratedb">CrateDB Overview</a></li>
-                    <li><a class="nav-link" href="/products/cratedb-cloud">CrateDB Cloud</a></li>
-                    <li><a class="nav-link" href="/products/cratedb-edge">CrateDB Edge</a></li>
-                    <li><a class="nav-link" href="/download#cratedb">CrateDB On-Premises</a></li>
-                    <li><a class="nav-link" href="/cratedb-comparison">Compare</a></li>
-                    <li><a class="nav-link" href="/pricing">Pricing</a></li>
-                    <li><a class="nav-link" href="/download">Download</a></li>
-                    <li><a class="nav-link" href="https://console.cratedb.cloud/?utm_source=website&amp;utm_medium=footernav&amp;utm_campaign=cratedbcloud" rel="noopener">CrateDB Cloud Login</a></li>
-                  </ul></div>
-                </div>
-                <div class="span2 footer-widget-content">
-                  <h3 class="footer-menu-title">Customers</h3>
-                  <div id="hs_cos_wrapper_module_16142721378942_" class="hs_cos_wrapper hs_cos_wrapper_widget hs_cos_wrapper_type_inline_rich_text"><ul>
-                    <li><a class="nav-link" href="/customers">Success Stories</a></li>
-                    <li><a class="nav-link" href="/use-cases">Use Cases</a></li>
-                    <li><a class="nav-link" href="/industries">Industries</a></li>
-                  </ul></div>
-                </div>
-                <div class="span2 footer-widget-content">
-                  <h3 class="footer-menu-title">Resources</h3>
-                  <div id="hs_cos_wrapper_module_16142721378942_" class="hs_cos_wrapper hs_cos_wrapper_widget hs_cos_wrapper_type_inline_rich_text"><ul>
-                    <li><a class="nav-link" href="/blog">Blog</a></li>
-                    <li><a class="nav-link" href="/event">Events</a></li>
-                    <li><a class="nav-link" href="/resources">Content Library</a></li>
-                    <li><a class="nav-link" href="/newsletter">Newsletter</a></li>
-                    <li><a class="nav-link" href="/resources/videos">Videos</a></li>
-                    <li><a class="nav-link" href="/resources/webinars">Webinars</a></li>
-                    <li><a class="nav-link" href="/resources/white-papers">White Papers</a></li>
-                  </ul></div>
-                </div>
-                <div class="span2 footer-widget-content">
-                  <h3 class="footer-menu-title">Developers</h3>
-                  <div id="hs_cos_wrapper_module_16142721378942_" class="hs_cos_wrapper hs_cos_wrapper_widget hs_cos_wrapper_type_inline_rich_text"><ul>
-                    <li><a class="nav-link" href="/docs">Get Started</a></li>
-                    <li><a class="nav-link" href="/docs/crate/reference/en/latest/">Reference</a></li>
-                    <li><a class="nav-link" href="/docs/crate/howtos/en/latest/">How-To Guides</a></li>
-                    <li><a class="nav-link" href="/support">Support</a></li>
-                    <li><a class="nav-link" href="/docs/sql-99/en/latest/">SQL 99 Docs</a></li>
-                    <li><a class="nav-link" href="/community">Community</a></li>
-                    <li><a class="nav-link" href="https://github.com/crate/crate" target="_blank" rel="noopener noreferrer">Github</a></li>
-                    <li><a class="nav-link" href="/community/contribute">Contribute</a></li>
-                  </ul></div>
-                </div>
-                <div class="span2 footer-widget-content">
-                  <h3 class="footer-menu-title">Company</h3>
-                  <div id="hs_cos_wrapper_module_16142721378942_" class="hs_cos_wrapper hs_cos_wrapper_widget hs_cos_wrapper_type_inline_rich_text"><ul>
-                    <li><a class="nav-link" href="/about">About us</a></li>
-                    <li><a class="nav-link" href="/jobs">Jobs</a></li>
-                    <li><a class="nav-link" href="/partners">Partners</a></li>
-                    <li><a class="nav-link" href="/press">Newsroom</a></li>
-                    <li><a class="nav-link" href="/security">Security</a></li>
-                    <li><a class="nav-link" href="/contact">Contact</a></li>
-                  </ul></div>
-                </div>
-              </div>
-              <div class="span2 footer-widget-content">
-                <h3 class="footer-menu-title">Follow us</h3>
-                <div class="footer__social">
-                  <div id="hs_cos_wrapper_footer_social" class="hs_cos_wrapper hs_cos_wrapper_widget hs_cos_wrapper_type_module"><div class="social-links">
-                    <a class="social-links__link nav-link" href="https://twitter.com/cratedb" target="_blank" rel="noopener">
-                      <span id="hs_cos_wrapper_footer_social_" class="hs_cos_wrapper hs_cos_wrapper_widget hs_cos_wrapper_type_icon social-links__icon"><svg version="1.0" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 512 512" aria-labelledby="twitter1" role="img"><title id="twitter1">Follow us on Twitter</title><g id="twitter1_layer"><path d="M459.37 151.716c.325 4.548.325 9.097.325 13.645 0 138.72-105.583 298.558-298.558 298.558-59.452 0-114.68-17.219-161.137-47.106 8.447.974 16.568 1.299 25.34 1.299 49.055 0 94.213-16.568 130.274-44.832-46.132-.975-84.792-31.188-98.112-72.772 6.498.974 12.995 1.624 19.818 1.624 9.421 0 18.843-1.3 27.614-3.573-48.081-9.747-84.143-51.98-84.143-102.985v-1.299c13.969 7.797 30.214 12.67 47.431 13.319-28.264-18.843-46.781-51.005-46.781-87.391 0-19.492 5.197-37.36 14.294-52.954 51.655 63.675 129.3 105.258 216.365 109.807-1.624-7.797-2.599-15.918-2.599-24.04 0-57.828 46.782-104.934 104.934-104.934 30.213 0 57.502 12.67 76.67 33.137 23.715-4.548 46.456-13.32 66.599-25.34-7.798 24.366-24.366 44.833-46.132 57.827 21.117-2.273 41.584-8.122 60.426-16.243-14.292 20.791-32.161 39.308-52.628 54.253z" /></g></svg></span>
-                      <span class="injected hidden">Follow us on Twitter</span>
-                    </a>
-                    <a class="social-links__link nav-link" href="https://www.linkedin.com/company/crateio/" target="_blank" rel="noopener">
-                      <span id="hs_cos_wrapper_footer_social__2" class="hs_cos_wrapper hs_cos_wrapper_widget hs_cos_wrapper_type_icon social-links__icon"><svg version="1.0" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 448 512" aria-labelledby="linkedin-in2" role="img"><title id="linkedin-in2">Follow us on LinkedIn</title><g id="linkedin-in2_layer"><path d="M100.3 480H7.4V180.9h92.9V480zM53.8 140.1C24.1 140.1 0 115.5 0 85.8 0 56.1 24.1 32 53.8 32c29.7 0 53.8 24.1 53.8 53.8 0 29.7-24.1 54.3-53.8 54.3zM448 480h-92.7V334.4c0-34.7-.7-79.2-48.3-79.2-48.3 0-55.7 37.7-55.7 76.7V480h-92.8V180.9h89.1v40.8h1.3c12.4-23.5 42.7-48.3 87.9-48.3 94 0 111.3 61.9 111.3 142.3V480z" /></g></svg></span>
-                      <span class="injected hidden">Follow us on LinkedIn</span>
-                    </a>
-                    <a class="social-links__link nav-link" href="https://www.facebook.com/crate.io/" target="_blank" rel="noopener">
-                      <span id="hs_cos_wrapper_footer_social__3" class="hs_cos_wrapper hs_cos_wrapper_widget hs_cos_wrapper_type_icon social-links__icon"><svg version="1.0" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 264 512" aria-labelledby="facebook-f3" role="img"><title id="facebook-f3">Follow us on Facebook</title><g id="facebook-f3_layer"><path d="M76.7 512V283H0v-91h76.7v-71.7C76.7 42.4 124.3 0 193.8 0c33.3 0 61.9 2.5 70.2 3.6V85h-48.2c-37.8 0-45.1 18-45.1 44.3V192H256l-11.7 91h-73.6v229" /></g></svg></span>
-                      <span class="injected hidden">Follow us on Facebook</span>
-                    </a>
-                    <a class="social-links__link nav-link" href="https://www.youtube.com/CrateIO" target="_blank" rel="noopener">
-                      <span id="hs_cos_wrapper_footer_social__4" class="hs_cos_wrapper hs_cos_wrapper_widget hs_cos_wrapper_type_icon social-links__icon"><svg version="1.0" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 576 512" aria-labelledby="youtube4" role="img"><title id="youtube4">Follow us on YouTube</title><g id="youtube4_layer"><path d="M549.655 124.083c-6.281-23.65-24.787-42.276-48.284-48.597C458.781 64 288 64 288 64S117.22 64 74.629 75.486c-23.497 6.322-42.003 24.947-48.284 48.597-11.412 42.867-11.412 132.305-11.412 132.305s0 89.438 11.412 132.305c6.281 23.65 24.787 41.5 48.284 47.821C117.22 448 288 448 288 448s170.78 0 213.371-11.486c23.497-6.321 42.003-24.171 48.284-47.821 11.412-42.867 11.412-132.305 11.412-132.305s0-89.438-11.412-132.305zm-317.51 213.508V175.185l142.739 81.205-142.739 81.201z" /></g></svg></span>
-                      <span class="injected hidden">Follow us on YouTube</span>
-                    </a>
-                    <a class="social-links__link nav-link" href="https://github.com/crate/crate" target="_blank" rel="noopener">
-                      <span id="hs_cos_wrapper_footer_social__5" class="hs_cos_wrapper hs_cos_wrapper_widget hs_cos_wrapper_type_icon social-links__icon"><svg version="1.0" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 496 512" aria-labelledby="github5" role="img"><title id="github5">Follow us on GitHub</title><g id="github5_layer"><path d="M165.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3.3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6zm-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5.3-6.2 2.3zm44.2-1.7c-2.9.7-4.9 2.6-4.6 4.9.3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9zM244.8 8C106.1 8 0 113.3 0 252c0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.3-14.3-112.3-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1C428.2 457.8 496 362.9 496 252 496 113.3 383.5 8 244.8 8zM97.2 352.9c-1.3 1-1 3.3.7 5.2 1.6 1.6 3.9 2.3 5.2 1 1.3-1 1-3.3-.7-5.2-1.6-1.6-3.9-2.3-5.2-1zm-10.8-8.1c-.7 1.3.3 2.9 2.3 3.9 1.6 1 3.6.7 4.3-.7.7-1.3-.3-2.9-2.3-3.9-2-.6-3.6-.3-4.3.7zm32.4 35.6c-1.6 1.3-1 4.3 1.3 6.2 2.3 2.3 5.2 2.6 6.5 1 1.3-1.3.7-4.3-1.3-6.2-2.2-2.3-5.2-2.6-6.5-1zm-11.4-14.7c-1.6 1-1.6 3.6 0 5.9 1.6 2.3 4.3 3.3 5.6 2.3 1.6-1.3 1.6-3.9 0-6.2-1.4-2.3-4-3.3-5.6-2z" /></g></svg></span>
-                      <span class="injected hidden">Follow us on GitHub</span>
-                    </a>
-                  </div></div>
-                </div>
-                <div class="hs_cos_wrapper_widget">
-                  <ul>
-                    <li><a href="/legal" class="nav-link">Legal</a></li>
-                    <li><a href="/legal/privacy-policy" class="nav-link">Privacy Policy</a></li>
-                    <li><a href="/legal/imprint" class="nav-link">Imprint</a></li>
-                  </ul>
-                  <br>
-                  <div class="img-div">
-                    <a href="/erdf" class="nav-link">
-                      <img src="https://19927462.fs1.hubspotusercontent-na1.net/hubfs/19927462/erdf.png" alt="erdf" style="width:101px; height:28px;" loading="lazy">
-                    </a>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </esi:remove>
-      <!--esi
-        <esi:include src="https://crate.io/_hcms/api/navi-footer" />
-        
-        <div class="w-col w-col-2 esi-mobile">
-          <ul class="footer-list w-list-unstyled" style="margin-top: 0; padding-left: 0;">
-            <li class="menu-item menu-item-type-post_type menu-item-object-page">
-              <a href="/legal/">Legal</a>
-            </li>
-            <li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-privacy-policy">
-              <a href="/legal/privacy-policy/">Privacy Policy</a>
-            </li>
-            <li class="menu-item menu-item-type-post_type menu-item-object-page">
-              <a href="/legal/imprint/">Imprint</a>
-            </li>
-            <li class="footer-listitem link-list">
-              <a class="footer-link-eu w-inline-block" href="/erdf/" title="crate.io"><img class="logo-eu" sizes="100px" src="{{ pathto('_static', 1) }}/images/erdf.png" alt="European Regional Development Funds Logo" width="100" height="28" loading="lazy"></a>
-            </li>
-          </ul>
-        </div>
-      -->
     </div>
-
-    {% endif %}
-    
   </div>
-</div>
 </footer>
-
-<div class="footer-subscription cr-nojs-hide">
-  <div class="content-wrapper container">
-    <div class="row">
-      <div class="col-md-3">
-        <h4>Subscribe to the CrateDB Newsletter now</h4>
-      </div>
-      <div class="col-md-9">
-        <div class="footer-subs-form">
-          <!--[if lte IE 8]>
-            <script charset="utf-8" type="text/javascript" src="//js.hsforms.net/forms/v2-legacy.js"></script>
-            <![endif]-->
-            <script charset="utf-8" type="text/javascript" src="//js.hsforms.net/forms/v2.js"></script>
-            <script>
-              hbspt.forms.create({
-                region: "na1",
-                portalId: "19927462",
-                formId: "76d1441f-eef8-4e8e-950d-9b66bf24bd8e"
-              });
-            </script>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

This removes the ESI of the footer and replaces it with the regular meta navigation that we were already using on SQL-99. While doing that, I also saw a typo and corrected links, this should be fixed with this PR. The newsletter module is now also above the navigation.