### PR TITLE
Last minute fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,6 @@ setup(
     install_requires=[
         "Jinja2>=3,<3.2",
         "docutils==0.16",
-        "docutils-stubs==0.0.22",
         "myst-parser[linkify]<3",
         "sphinx>=4.6,<7",
         "sphinx-copybutton>=0.3.1,<1",

--- a/src/crate/theme/rtd/crate/static/css/crateio-ng.css
+++ b/src/crate/theme/rtd/crate/static/css/crateio-ng.css
@@ -37,7 +37,7 @@
 }
 .feedback-compact-content div.sd-summary-content {
   position: fixed;
-  z-index: 150;
+  z-index: 175;
   background: #fff;
   border: 1px solid #ccc;
 }


### PR DESCRIPTION
## About

- Dependencies: Don't install `docutils-stubs` at runtime.
- UI: Increase `z-index` of feedback chooser content, addressing GH-413.
