### PR TITLE
Fix margin on page tools element

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ CHANGES
 Unreleased
 ----------
 
+- Fix margin on page tools element
+
 
 2023/08/03 0.29.0
 -----------------

--- a/src/crate/theme/rtd/crate/github_feedback_compact.html
+++ b/src/crate/theme/rtd/crate/github_feedback_compact.html
@@ -5,7 +5,7 @@ set source_path = conf_py_path + pagename + suffix
 %}
 
 <div class="feedback-compact-container">
-  <details class="sd-sphinx-override sd-dropdown sd-card sd-mb-3 feedback-compact-content">  <!-- open="" -->
+  <details class="sd-sphinx-override sd-dropdown sd-card feedback-compact-content">  <!-- open="" -->
     <summary class="sd-summary-title sd-card-header">
       <span class="fa fa-gear fa-fw"></span>
       <span class="feedback-compact-title">&nbsp; Feedback</span>

--- a/src/crate/theme/rtd/crate/version_chooser.html
+++ b/src/crate/theme/rtd/crate/version_chooser.html
@@ -1,7 +1,7 @@
 <!-- Version chooser component -->
 
 <div class="version-chooser-container">
-  <details class="sd-sphinx-override sd-dropdown sd-card sd-mb-3 version-chooser-content">  <!-- open="" -->
+  <details class="sd-sphinx-override sd-dropdown sd-card version-chooser-content">  <!-- open="" -->
     <summary class="sd-summary-title sd-card-header version-chooser-title">
       <div><a href="{{ pathto(master_doc) }}">v:{{ current_version }}</a></div>
 


### PR DESCRIPTION
## About

There is a slight problem with that margin of the new "page tools" element, which bumps into the text/content section. It is not so bad when it is collapsed, but when expanding it, it wobbles the text around.

![image](https://github.com/crate/crate-docs-theme/assets/453543/30122253-9abc-46af-8350-947af190abbb)
