### PR TITLE
Modernize and fix JS and CSS includes, and extend demo pages

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Unreleased
 ----------
 
 - Fix margin on page tools element
+- Modernize and fix JS and CSS includes
 
 
 2023/08/03 0.29.0

--- a/docs/myst/togglebutton.md
+++ b/docs/myst/togglebutton.md
@@ -1,0 +1,54 @@
+# Sphinx Togglebutton
+
+## About
+
+[sphinx-togglebutton] is a small Sphinx extension to make it possible to add a
+"toggle button" to sections of your page. This allows you to:
+
+- Collapse Sphinx admonitions (notes, warnings, etc.) so that their content is
+  hidden until users click a toggle button.
+- Collapse arbitrary chunks of content on your page with a collapse directive.
+
+
+## Examples
+
+
+### Collapsed
+
+
+The default version is to display the collapsed variant of the element.
+
+:::{note}
+:class: dropdown
+
+This is my note.
+:::
+
+
+### Opened
+
+You may also **show the content by default**.
+
+:::{note}
+:class: dropdown, toggle-shown
+
+This is my note.
+:::
+
+
+### Container
+
+You can also use containers to add arbitrary toggle-able code. For example,
+here's a container with an image inside.
+
+:::::{container} toggle, toggle-hidden
+::::{admonition} Look at that, an image!
+
+:::{image} https://media.giphy.com/media/mW05nwEyXLP0Y/giphy.gif
+:::
+
+::::
+:::::
+
+
+[sphinx-togglebutton]: https://github.com/executablebooks/sphinx-togglebutton

--- a/docs/rst/crossref.rst
+++ b/docs/rst/crossref.rst
@@ -1,0 +1,5 @@
+################
+Cross-references
+################
+
+Nothing here, yet.

--- a/docs/rst/image-figure.rst
+++ b/docs/rst/image-figure.rst
@@ -1,0 +1,5 @@
+##################
+Images and figures
+##################
+
+Nothing here, yet.

--- a/docs/rst/togglebutton.rst
+++ b/docs/rst/togglebutton.rst
@@ -1,0 +1,56 @@
+###################
+Sphinx Togglebutton
+###################
+
+
+*****
+About
+*****
+
+`sphinx-togglebutton`_ is a small Sphinx extension to make it possible to add a
+"toggle button" to sections of your page. This allows you to:
+
+- Collapse Sphinx admonitions (notes, warnings, etc.) so that their content is
+  hidden until users click a toggle button.
+- Collapse arbitrary chunks of content on your page with a collapse directive.
+
+
+********
+Examples
+********
+
+
+Collapsed
+=========
+
+The default version is to display the collapsed variant of the element.
+
+.. note::
+    :class: dropdown
+
+    This is my note.
+
+Opened
+======
+
+You may also **show the content by default**.
+
+.. note::
+    :class: dropdown, toggle-shown
+
+    This is my note.
+
+Container
+=========
+
+You can also use containers to add arbitrary toggle-able code. For example,
+here's a container with an image inside.
+
+.. container:: toggle, toggle-hidden
+
+    .. admonition:: Look at that, an image!
+
+        .. image:: https://media.giphy.com/media/mW05nwEyXLP0Y/giphy.gif
+
+
+.. _sphinx-togglebutton: https://github.com/executablebooks/sphinx-togglebutton

--- a/src/crate/theme/rtd/crate/base.html
+++ b/src/crate/theme/rtd/crate/base.html
@@ -85,43 +85,42 @@
 {%- endmacro %}
 
 {%- macro script() %}
-    <script type="text/javascript">
-      /*
-      var DOCUMENTATION_OPTIONS = {
-        URL_ROOT:    '{{ url_root }}',
-        VERSION:     '{{ release|e }}',
-        COLLAPSE_INDEX: false,
-        FILE_SUFFIX: '{{ '' if no_search_suffix else file_suffix }}',
-        HAS_SOURCE:  {{ has_source|lower }}
-      };
-      */
-    </script>
 
     <link rel="preconnect" href="https://ajax.googleapis.com/" crossorigin>
     <link rel="dns-prefetch" href="https://ajax.googleapis.com/">
     <link rel="preconnect" href="https://cdn.crate.io/" crossorigin>
     <link rel="dns-prefetch" href="https://cdn.crate.io/">
 
-    <script id="documentation_options" data-url_root="{{ url_root }}" src="{{ pathto('_static/documentation_options.js', 1) }}?ver={{ theme_ver }}"></script>
-    <script src="{{ pathto('_static/bundle/main.js', 1) }}?ver={{ theme_ver }}"></script>
+    {{ js_tag("_static/bundle/main.js") }}
 
-    {%- for scriptfile in script_files %}
-    <script type="text/javascript" src="{{ pathto(scriptfile, 1) }}?ver={{ theme_ver }}"></script>
+    {%- for js in script_files %}
+    {{ js_tag(js) }}
     {%- endfor %}
-    {%- for scriptfile in extra_script_files %}
-    <script type="text/javascript" src="{{ pathto(scriptfile, 1) }}?ver={{ theme_ver }}"></script>
+
+    {%- for js in extra_script_files %}
+    {{ js_tag(js) }}
     {%- endfor %}
+
 {%- endmacro %}
 
 {%- macro css() %}
-    <link rel="stylesheet" href="{{ pathto('_static/' + style, 1) }}?ver={{ theme_ver }}" type="text/css" />
-    <link rel="stylesheet" href="{{ pathto('_static/pygments.css', 1) }}?ver={{ theme_ver }}" type="text/css" />
-    {%- for cssfile in css_files %}
-    <link rel="stylesheet" href="{{ pathto(cssfile, 1) }}?ver={{ theme_ver }}" type="text/css" />
+
+    {%- for css in css_files %}
+      {%- if css|attr("filename") %}
+    {{ css_tag(css) }}
+      {%- else %}
+    <link rel="stylesheet" href="{{ pathto(css, 1)|e }}" type="text/css" />
+      {%- endif %}
     {%- endfor %}
-    {%- for cssfile in extra_css_files %}
-    <link rel="stylesheet" href="{{ pathto(cssfile, 1) }}?ver={{ theme_ver }}" type="text/css" />
+
+    {%- for css in extra_css_files %}
+      {%- if css|attr("filename") %}
+    {{ css_tag(css) }}
+      {%- else %}
+    <link rel="stylesheet" href="{{ pathto(css, 1)|e }}" type="text/css" />
+      {%- endif %}
     {%- endfor %}
+
 {%- endmacro %}
 
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
@@ -133,7 +132,9 @@
     {%- endblock %}
     {{ css() }}
     {%- if not embedded %}
-    {{ script() }}
+    {%- block scripts %}
+    {{- script() }}
+    {%- endblock %}
     {%- if use_opensearch %}
     <link rel="search" type="application/opensearchdescription+xml"
           title="{% trans docstitle=docstitle|e %}Search within {{ docstitle }}{% endtrans %}"

--- a/src/crate/theme/rtd/crate/layout.html
+++ b/src/crate/theme/rtd/crate/layout.html
@@ -39,6 +39,10 @@
 
   {% endblock %}
 
+  {%- block scripts %}
+    {{ super() }}
+  {%- endblock %}
+
   {# Silence the sidebar's, relbar's #}
   {% block header %}{% endblock %}
   {% block relbar1 %}{% endblock %}


### PR DESCRIPTION
## About

Updating the mechanics of JS/CSS asset includes based on Sphinx 3 and newer. For including assets within HTML templates, the `js_tag()` and `css_tag()` helper functions are now available within the HTML context.

### See also
- https://github.com/sphinx-doc/sphinx/blob/master/sphinx/themes/basic/layout.html
- https://github.com/sphinx-doc/sphinx/blob/master/sphinx/themes/classic/layout.html

## Problems
```javascript
Uncaught ReferenceError: toggleOpenOnPrint is not defined
Uncaught ReferenceError: togglebuttonSelector is not defined
```

```html
<script type="text/javascript" src="None?ver=0.29.0"></script>
<script type="text/javascript" src="None?ver=0.29.0"></script>
<script type="text/javascript" src="None?ver=0.29.0"></script>
```


## References
- GH-383
