### PR TITLE
Fix pagetools dropdown: Group elements to define mutual toggle-opening

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Unreleased
 
 - Fix margin on page tools element
 - Modernize and fix JS and CSS includes
+- Fix pagetools dropdown: Group elements to define mutual toggle-opening.
+  Thanks, @kojinkai and @msbt.
 
 
 2023/08/03 0.29.0

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
         "sphinx>=4.6,<7",
         "sphinx-copybutton>=0.3.1,<1",
         "sphinx-design<1",
-        "sphinx-design-elements==0.1.0",
+        "sphinx-design-elements==0.2.1",
         "sphinx-inline-tabs",
         "sphinx-sitemap>=2,<3",
         "sphinx-subfigure<1",

--- a/src/crate/theme/rtd/crate/layout.html
+++ b/src/crate/theme/rtd/crate/layout.html
@@ -95,7 +95,7 @@
         <div class="col-md-8 col-lg-9" role="main">
           <div class="wrapper-content-right">
 
-            <div class="page-tools">
+            <div class="page-tools dropdown-group">
             {% if display_github %}
             {% include "github_feedback_compact.html" %}
             {%- endif %}


### PR DESCRIPTION
## About

> Both the settings and version flyout menus can be opened at the same time. Perhaps opening one menu should close the other open menu.

Resolved using an extension to [sphinx-design dropdowns](https://sphinx-design.readthedocs.io/en/latest/dropdowns.html), implementing a similar behavior like [using CSS toggle-group to group exclusive toggles](https://blog.logrocket.com/advanced-guide-css-toggle-pseudo-class/#using-toggle-group-exclusive-toggles), based on a JavaScript implementation provided by @msbt. Thanks!

## Preview

https://crate-docs-theme--419.org.readthedocs.build/en/419/

## References
- GH-413
- GH-417
- https://github.com/panodata/sphinx-design-elements/pull/15
- https://github.com/panodata/sphinx-design-elements/pull/19
