### PR TITLE
Improve version chooser to use the same page when switching versions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ Unreleased
 - Modernize and fix JS and CSS includes
 - Fix pagetools dropdown: Group elements to define mutual toggle-opening.
   Thanks, @kojinkai and @msbt.
+- Improve version chooser to use the same page when switching versions.
+  Thanks, @hlcianfagna.
 
 
 2023/08/03 0.29.0

--- a/src/crate/theme/rtd/crate/version_chooser.html
+++ b/src/crate/theme/rtd/crate/version_chooser.html
@@ -15,7 +15,7 @@
     <div class="sd-summary-content sd-card-body docutils">
       {% for slug, url in versions %}
       <p class="sd-card-text">
-        <a href="https://crate.io/{{ theme_canonical_url_path|replace('en/latest/', '') }}{{ rtd_language }}/{{ slug }}/" class="version-chooser-link">{{ slug }}</a>
+        <a href="https://crate.io/{{ theme_canonical_url_path|replace('en/latest/', '') }}{{ rtd_language }}/{{ slug }}/{{ pagename }}.html" class="version-chooser-link">{{ slug }}</a>
       </p>
       {% endfor %}
     </div>


### PR DESCRIPTION
## About

When switching versions, the version chooser lost track of the current page. This patch intends to fix it, as suggested by @hlcianfagna. Thank you!

## References

- GH-408
