### PR TITLE
Fix text alignment with sphinx-togglebutton

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ Unreleased
   Thanks, @kojinkai and @msbt.
 - Improve version chooser to use the same page when switching versions.
   Thanks, @hlcianfagna.
+- Fix text alignment with sphinx-togglebutton. Thanks, @msbt.
 
 
 2023/08/03 0.29.0

--- a/docs/build.json
+++ b/docs/build.json
@@ -1,5 +1,5 @@
 {
   "schemaVersion": 1,
   "label": "docs build",
-  "message": "2.1.0"
+  "message": "2.1.1"
 }

--- a/src/crate/theme/rtd/crate/static/css/crateio-ng.css
+++ b/src/crate/theme/rtd/crate/static/css/crateio-ng.css
@@ -50,3 +50,10 @@ details.feedback-compact-content:not([open]) .feedback-compact-title {
 .feedback-compact-link {
   color: #222222;
 }
+
+
+/* Fix text alignment with sphinx-togglebutton */
+button.toggle-button {
+  display: inline-flex;
+  align-items: center;
+}


### PR DESCRIPTION
## About

This patch fixes GH-421. The text within a sphinx-togglebutton admonition was slightly misaligned. Thanks, @msbt.

![image](https://github.com/crate/crate-docs-theme/assets/453543/21954373-d447-4571-92e5-42fd93fedfc7)
