### PR TITLE
Fix CSS: Remove font size of blockquote override

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ CHANGES
 Unreleased
 ----------
 
+- Fix CSS: Remove font size of blockquote override
+
 
 2023/08/11 0.29.2
 -----------------

--- a/docs/myst/infocard.md
+++ b/docs/myst/infocard.md
@@ -83,8 +83,8 @@ A flexible software breadboard for ISM RF packet radio nodes, relays, and gatewa
 A mountain goat with long horns standing on a grassy hill.
 
 :::{div} text-small
-**Author:** Jaromír Kalina, [@jkalinaofficial](https://unsplash.com/@jkalinaofficial) \
-**Contact:** Czech Republic, <https://jkalina.carrd.co/> \
+
+**Author:** Jaromír Kalina, Czech Republic, [@jkalinaofficial](https://unsplash.com/@jkalinaofficial) \
 **Exposé:** https://unsplash.com/photos/spdQ1dVuIHw \
 **Source:** [Unsplash -- The internet’s source for visuals](https://unsplash.com/)
 :::

--- a/docs/rst/infocard.rst
+++ b/docs/rst/infocard.rst
@@ -88,8 +88,7 @@ Example 3
 
         .. div:: text-small
 
-            | **Author:** Jaromír Kalina, `@jkalinaofficial <https://unsplash.com/@jkalinaofficial>`_
-            | **Contact:** Czech Republic, https://jkalina.carrd.co/
+            | **Author:** Jaromír Kalina, Czech Republic, `@jkalinaofficial <https://unsplash.com/@jkalinaofficial>`_
             | **Exposé:** https://unsplash.com/photos/spdQ1dVuIHw
             | **Source:** `Unsplash -- The internet’s source for visuals <https://unsplash.com/>`_
 

--- a/src/crate/theme/rtd/crate/static/css/crateio.css
+++ b/src/crate/theme/rtd/crate/static/css/crateio.css
@@ -112,7 +112,6 @@ blockquote {
   margin-bottom: 16px;
   padding: 10px 20px;
   border-left-color: #000;
-  font-size: 24px;
   line-height: 1.5em;
 }
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

fix for https://github.com/crate/crate-docs-theme/issues/382
