### PR TITLE
Improve version chooser: Remove ambiguous link on "current" version to root document

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Unreleased
 ----------
 
 - Fix CSS: Remove font size of blockquote override
+- Improve version chooser: Remove ambiguous link to master doc.
 
 
 2023/08/11 0.29.2

--- a/src/crate/theme/rtd/crate/version_chooser.html
+++ b/src/crate/theme/rtd/crate/version_chooser.html
@@ -3,8 +3,7 @@
 <div class="version-chooser-container">
   <details class="sd-sphinx-override sd-dropdown sd-card version-chooser-content">  <!-- open="" -->
     <summary class="sd-summary-title sd-card-header version-chooser-title">
-      <div><a href="{{ pathto(master_doc) }}">v:{{ current_version }}</a></div>
-
+      <span>{{ current_version }}</span>
       <div class="sd-summary-down docutils">
         <svg version="1.1" width="1.5em" height="1.5em" class="sd-octicon sd-octicon-chevron-down" viewBox="0 0 24 24" aria-hidden="true"><path fill-rule="evenodd" d="M5.22 8.72a.75.75 0 000 1.06l6.25 6.25a.75.75 0 001.06 0l6.25-6.25a.75.75 0 00-1.06-1.06L12 14.44 6.28 8.72a.75.75 0 00-1.06 0z"></path></svg>
       </div>


### PR DESCRIPTION
## About

Based on the suggestion from @hlcianfagna (thanks!) at https://github.com/crate/crate-docs-theme/issues/408#issuecomment-1696938367, this patch removes the ambiguous link on the "current" version, which points to the root document, altogether.

## Preview

https://crate-docs-theme--428.org.readthedocs.build/en/428/
