### PR TITLE
Bring back lost navigation items to database drivers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Unreleased
 
 - Fix CSS: Remove font size of blockquote override
 - Improve version chooser: Remove ambiguous link to master doc.
+- Bring back lost navigation items to database drivers
 
 
 2023/08/11 0.29.2

--- a/src/crate/theme/rtd/crate/sidebartoc.html
+++ b/src/crate/theme/rtd/crate/sidebartoc.html
@@ -66,11 +66,60 @@
   <li class="navleft-item"><a href="/docs/crate/crash/">Crash CLI</a></li>
   {% endif %}
 
-  {% if project == 'CrateDB: Clients and Tools' %}
+  {%
+  set driver_projects = [
+    'CrateDB: Clients and Tools',
+    'CrateDB JDBC', 'CrateDB DBAL', 'CrateDB PDO', 'CrateDB Python', 'CrateDB Npgsql'
+  ]
+  %}
+  {% if project in driver_projects %}
     <li class="current">
       <a class="current-active" href="{{ pathto(master_doc) }}">Drivers and Integrations</a>
       {{ toctree(maxdepth=3|toint, collapse=True, includehidden=theme_globaltoc_includehidden|tobool) }}
     </li>
+
+    <!-- Section C. -->
+    {% if project == 'CrateDB JDBC' %}
+    <li class="current border-top">
+      <a class="current-active" href="{{ pathto(master_doc) }}">JDBC</a>
+      {{ toctree(maxdepth=1|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
+    </li>
+    {% else %}
+    <li class="navleft-item border-top"><a href="/docs/jdbc/">JDBC</a></li>
+    {% endif %}
+    {% if project == 'CrateDB DBAL' %}
+    <li class="current">
+      <a class="current-active" href="{{ pathto(master_doc) }}">PHP DBAL</a>
+      {{ toctree(maxdepth=1|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
+    </li>
+    {% else %}
+    <li class="navleft-item"><a href="/docs/dbal/">PHP DBAL</a></li>
+    {% endif %}
+    {% if project == 'CrateDB PDO' %}
+    <li class="current">
+      <a class="current-active" href="{{ pathto(master_doc) }}">PHP PDO</a>
+      {{ toctree(maxdepth=1|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
+    </li>
+    {% else %}
+    <li class="navleft-item"><a href="/docs/pdo/">PHP PDO</a></li>
+    {% endif %}
+    {% if project == 'CrateDB Python' %}
+    <li class="current">
+      <a class="current-active" href="{{ pathto(master_doc) }}">Python</a>
+      {{ toctree(maxdepth=1|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
+    </li>
+    {% else %}
+    <li class="navleft-item"><a href="/docs/python/">Python</a></li>
+    {% endif %}
+    {% if project == 'CrateDB Npgsql' %}
+    <li class="current">
+      <a class="current-active" href="{{ pathto(master_doc) }}">.NET Npgsql</a>
+      {{ toctree(maxdepth=1|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
+    </li>
+    {% else %}
+    <li class="navleft-item"><a href="/docs/npgsql/">.NET Npgsql</a></li>
+    {% endif %}
+
   {% else %}
     <li class="navleft-item"><a href="/docs/crate/clients-tools/">Drivers and Integrations</a></li>
   {% endif %}


### PR DESCRIPTION
## About

Fix GH-426. Removing the navigation items to the database drivers with 490ac7e6587 was a silly idea.

This patch brings them back, but nests them within the "Drivers and Integration" section, so they do not take screen space when browsing the other sections. Effectively, it is still a net improvement compared to the original situation.

## Preview

No preview available. Needs to be rendered by either `crate-clients-tools`, or other database driver projects.

