### PR TITLE
Improve primary navigation on the database driver section once more

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ CHANGES
 Unreleased
 ----------
 
+- Improve primary navigation on the database driver section once more
+
 
 2023/08/30 0.29.3
 -----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,8 +11,10 @@ Unreleased
 -----------------
 
 - Fix CSS: Remove font size of blockquote override. Thanks, @msbt.
-- Improve version chooser: Remove ambiguous link to root document
-- Bring back lost navigation items to database drivers
+- Improve version chooser: Remove ambiguous link to root document.
+  Thanks, @hlcianfagna.
+- Bring back lost navigation items to database drivers. Thanks,
+  @proddata.
 
 
 2023/08/11 0.29.2

--- a/src/crate/theme/rtd/crate/sidebartoc.html
+++ b/src/crate/theme/rtd/crate/sidebartoc.html
@@ -73,55 +73,61 @@
   ]
   %}
   {% if project in driver_projects %}
-    <li class="current">
+  <li class="current">
+    {% if project == 'CrateDB: Clients and Tools' %}
       <a class="current-active" href="{{ pathto(master_doc) }}">Drivers and Integrations</a>
       {{ toctree(maxdepth=3|toint, collapse=True, includehidden=theme_globaltoc_includehidden|tobool) }}
-    </li>
-
-    <!-- Section C. -->
-    {% if project == 'CrateDB JDBC' %}
-    <li class="current border-top">
-      <a class="current-active" href="{{ pathto(master_doc) }}">JDBC</a>
-      {{ toctree(maxdepth=1|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
-    </li>
     {% else %}
-    <li class="navleft-item border-top"><a href="/docs/jdbc/">JDBC</a></li>
+      <a class="current-active" href="/docs/crate/clients-tools/">Drivers and Integrations</a>
     {% endif %}
-    {% if project == 'CrateDB DBAL' %}
-    <li class="current">
-      <a class="current-active" href="{{ pathto(master_doc) }}">PHP DBAL</a>
-      {{ toctree(maxdepth=1|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
-    </li>
-    {% else %}
-    <li class="navleft-item"><a href="/docs/dbal/">PHP DBAL</a></li>
-    {% endif %}
-    {% if project == 'CrateDB PDO' %}
-    <li class="current">
-      <a class="current-active" href="{{ pathto(master_doc) }}">PHP PDO</a>
-      {{ toctree(maxdepth=1|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
-    </li>
-    {% else %}
-    <li class="navleft-item"><a href="/docs/pdo/">PHP PDO</a></li>
-    {% endif %}
-    {% if project == 'CrateDB Python' %}
-    <li class="current">
-      <a class="current-active" href="{{ pathto(master_doc) }}">Python</a>
-      {{ toctree(maxdepth=1|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
-    </li>
-    {% else %}
-    <li class="navleft-item"><a href="/docs/python/">Python</a></li>
-    {% endif %}
-    {% if project == 'CrateDB Npgsql' %}
-    <li class="current">
-      <a class="current-active" href="{{ pathto(master_doc) }}">.NET Npgsql</a>
-      {{ toctree(maxdepth=1|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
-    </li>
-    {% else %}
-    <li class="navleft-item"><a href="/docs/npgsql/">.NET Npgsql</a></li>
-    {% endif %}
-
+    <ul>
+      <!-- Section C. -->
+      {% if project == 'CrateDB JDBC' %}
+      <li class="current">
+        <a class="current-active" href="{{ pathto(master_doc) }}">JDBC</a>
+        {{ toctree(maxdepth=3|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
+      </li>
+      {% else %}
+      <li class="navleft-item"><a href="/docs/jdbc/">JDBC</a></li>
+      {% endif %}
+      {% if project == 'CrateDB DBAL' %}
+      <li class="current">
+        <a class="current-active" href="{{ pathto(master_doc) }}">PHP DBAL</a>
+        {{ toctree(maxdepth=3|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
+      </li>
+      {% else %}
+      <li class="navleft-item"><a href="/docs/dbal/">PHP DBAL</a></li>
+      {% endif %}
+      {% if project == 'CrateDB PDO' %}
+      <li class="current">
+        <a class="current-active" href="{{ pathto(master_doc) }}">PHP PDO</a>
+        {{ toctree(maxdepth=3|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
+      </li>
+      {% else %}
+      <li class="navleft-item"><a href="/docs/pdo/">PHP PDO</a></li>
+      {% endif %}
+      {% if project == 'CrateDB Python' %}
+      <li class="current">
+        <a class="current-active" href="{{ pathto(master_doc) }}">Python</a>
+        {{ toctree(maxdepth=3|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
+      </li>
+      {% else %}
+      <li class="navleft-item"><a href="/docs/python/">Python</a></li>
+      {% endif %}
+      {% if project == 'CrateDB Npgsql' %}
+      <li class="current">
+        <a class="current-active" href="{{ pathto(master_doc) }}">.NET Npgsql</a>
+        {{ toctree(maxdepth=3|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
+      </li>
+      {% else %}
+      <li class="navleft-item"><a href="/docs/npgsql/">.NET Npgsql</a></li>
+      {% endif %}
+    </ul>
+  </li>
   {% else %}
-    <li class="navleft-item"><a href="/docs/crate/clients-tools/">Drivers and Integrations</a></li>
+  <li class="navleft-item">
+    <a href="/docs/crate/clients-tools/">Drivers and Integrations</a>
+  </li>
   {% endif %}
 
   <!-- Section D. -->


### PR DESCRIPTION
## About

Another attempt to fix the primary navigation on the database driver section.

## Problem

While GH-429 brought back the navigation items to the database drivers, it is still not quite right, when actually using them.

![image](https://github.com/crate/crate-docs-theme/assets/453543/31d5432a-2a17-41bb-91d5-acd901550556)
