### PR TITLE
Stop displaying the edit/view source link on synthetic pages

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ CHANGES
 Unreleased
 ----------
 
+- Stop displaying the edit/view source link on synthetic pages, for example,
+  the ``search.html`` page. Thanks, @msbt.
+
 
 2023/09/06 0.29.6
 -----------------

--- a/src/crate/theme/rtd/crate/github_feedback_compact.html
+++ b/src/crate/theme/rtd/crate/github_feedback_compact.html
@@ -41,6 +41,9 @@ set source_path = conf_py_path + pagename + suffix
         }}{{ '%0A'
         }}" target="_blank" title="Suggest improvement">Suggest improvement</a>
       </p>
+
+      {# On synthetic pages, do not display Edit/View page source #}
+      {% if synthetic_page is not defined or synthetic_page is sameas false %}
       <p class="sd-card-text">
         <span class="fa fa-edit fa-fw"></span>
         &nbsp;
@@ -51,6 +54,8 @@ set source_path = conf_py_path + pagename + suffix
         &nbsp;
         <a id="docs-feedback-open-github" class="feedback-compact-link" href="https://{{ github_host|default('github.com') }}/{{ github_user }}/{{ github_repo }}/{{ theme_vcs_pageview_mode|default('blob') }}/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ suffix }}?plain=1" rel="noopener" target="_blank" title="View page source on GitHub">View&nbsp;page source</a>
       </p>
+      {% endif %}
+
     </div>
   </details>
 </div>

--- a/src/crate/theme/rtd/crate/search.html
+++ b/src/crate/theme/rtd/crate/search.html
@@ -8,6 +8,10 @@
     :license: BSD, see LICENSE for details.
 #}
 {%- extends "layout.html" %}
+
+{# On synthetic pages, do not display Edit/View page source #}
+{% set synthetic_page = true %}
+
 {% set title = _('Search') %}
 
 {% block extra_head %}


### PR DESCRIPTION
For example, the `search.html` page does not need it, and produces links yielding "404 Not Found" responses.
This patch intends to fix GH-437.
