### PR TITLE
Primary navigation: Use `maxdepth=2` for serving "CrateDB Cloud"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,10 @@ CHANGES
 Unreleased
 ----------
 
+- Primary navigation: Use ``maxdepth=2`` for serving "CrateDB Cloud"
+  That means, only pull headings up to the second level into the menu.
+
+
 2023/09/19 0.29.7
 -----------------
 

--- a/src/crate/theme/rtd/crate/sidebartoc.html
+++ b/src/crate/theme/rtd/crate/sidebartoc.html
@@ -13,7 +13,7 @@
   {% if project == 'CrateDB Cloud' %}
     <li class="current">
       <a class="current-active" href="{{ pathto(master_doc) }}">CrateDB Cloud</a>
-      {{ toctree(maxdepth=3|toint, collapse=True, includehidden=theme_globaltoc_includehidden|tobool) }}
+      {{ toctree(maxdepth=2|toint, collapse=True, includehidden=theme_globaltoc_includehidden|tobool) }}
     </li>
   {% else %}
     <li class="navleft-item"><a href="/docs/cloud/">CrateDB Cloud</a></li>


### PR DESCRIPTION
## About

Apparently, "Cloud Docs" pulled too many levels of page headings into the primary navigation menu (three). This patch decreases that to use only two levels.
