### PR TITLE
Leftnav: Use `Installation` instead of `Self-Managed`

### DIFF
--- a/src/crate/theme/rtd/crate/sidebartoc.html
+++ b/src/crate/theme/rtd/crate/sidebartoc.html
@@ -19,7 +19,7 @@
     <li class="navleft-item"><a href="/docs/cloud/">CrateDB Cloud</a></li>
   {% endif %}
 
-  <li class="navleft-item"><a href="/docs/guide/install/">Self-Managed</a></li>
+  <li class="navleft-item"><a href="/docs/guide/install/">Installation</a></li>
 
   {% if project == 'CrateDB: Guide' %}
     <li class="current">


### PR DESCRIPTION
We found an agreement about a label. What the title says.