### PR TITLE
add class to remove margin-bottom

### DIFF
--- a/src/crate/theme/rtd/crate/static/css/custom.css
+++ b/src/crate/theme/rtd/crate/static/css/custom.css
@@ -2366,3 +2366,7 @@ ul.search li {
 .injected {
   display: none;
 }
+
+.mb-0 {
+  margin-bottom: 0 !important;
+}


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

to override `margin-bottom` when it is set somewhere where it's not wanted