### PR TITLE
Rename menu item "Drivers and Integrations" to "Ecosystem Catalog"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Unreleased
 - Update icons with the corresponding colors
 - Introduce a secondary color for improved accessibilty
 - Small improvement for the version/feedback dropdown on mobile
+- Rename menu item "Drivers and Integrations" to "Ecosystem Catalog"
 
 
 2024/03/05 0.30.0

--- a/src/crate/theme/rtd/crate/sidebartoc.html
+++ b/src/crate/theme/rtd/crate/sidebartoc.html
@@ -68,10 +68,10 @@
   {% if project in driver_projects %}
   <li class="current">
     {% if project == 'CrateDB: Clients and Tools' %}
-      <a class="current-active" href="{{ pathto(master_doc) }}">Drivers and Integrations</a>
+      <a class="current-active" href="{{ pathto(master_doc) }}">Ecosystem Catalog</a>
       {{ toctree(maxdepth=3|toint, collapse=True, includehidden=theme_globaltoc_includehidden|tobool) }}
     {% else %}
-      <a class="current-active" href="/docs/crate/clients-tools/">Drivers and Integrations</a>
+      <a class="current-active" href="/docs/crate/clients-tools/">Ecosystem Catalog</a>
     {% endif %}
     <ul>
       <!-- Section C. -->
@@ -119,7 +119,7 @@
   </li>
   {% else %}
   <li class="navleft-item">
-    <a href="/docs/crate/clients-tools/">Drivers and Integrations</a>
+    <a href="/docs/crate/clients-tools/">Ecosystem Catalog</a>
   </li>
   {% endif %}
 


### PR DESCRIPTION
## About

After all the tutorials have been refactored into the CrateDB Guide with https://github.com/crate/crate-clients-tools/pull/82 recently, the enumeration of catalog items here became a bit of a lost place.

This patch concludes the renovation by effectively repurposing that documentation section into a (preliminary) ecosystem software catalog/gallery, in the spirit how [others](https://cloud.mongodb.com/ecosystem/) [are](https://catalog.redhat.com/) [running](https://hub.docker.com/) [them](https://hub.meltano.com/).

## References
- https://github.com/crate/crate-clients-tools/pull/107
