### PR TITLE
Fix compatibility issue with Python 3.8

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-latest']
-        python-version: ['3.10', '3.11']
+        python-version: ['3.8', '3.11']
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ CHANGES
 
 Unreleased
 ----------
-
+- Fix compatibility issue with Python 3.8, by updating to
+  sphinx-design-elements 0.3.1
 
 2024/04/06 0.31.0
 -----------------

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
         "sphinx>=4.6,<7",
         "sphinx-copybutton>=0.3.1,<1",
         "sphinx-design<1",
-        "sphinx-design-elements==0.3.0",
+        "sphinx-design-elements<1",
         "sphinx-inline-tabs",
         "sphinx-sitemap>=2,<3",
         "sphinx-subfigure<1",


### PR DESCRIPTION
... by updating to sphinx-design-elements 0.3.1.

Effectively, relax pinning "sphinx-design-elements<1" so fixes can arrive more quickly, shifting the responsibility about running breaking changes to sde, needing to bump to 1.0.0 if any.
