### PR TITLE
Attempt to fix the missing `index.html` in canonical URLs

### DIFF
--- a/src/crate/theme/rtd/crate/base.html
+++ b/src/crate/theme/rtd/crate/base.html
@@ -141,6 +141,22 @@
           href="{{ pathto('_static/opensearch.xml', 1) }}"/>
     {%- endif %}
 
+    {%- if canonical_url %}
+    {%- if pagename == "index" %}
+        {%- set canonical_page = "index.html" %}
+    {%- elif pagename.endswith("/index") %}
+        {%- set canonical_page = pagename[:-("/index"|length)] + "/index.html" %}
+    {%- else %}
+        {%- set ending = "/" if 'dirhtml' in builder else ".html" %}
+        {%- set canonical_page = pagename + ending %}
+    {%- endif %}
+    <!--
+    Always link to the latest version, as canonical.
+    https://docs.readthedocs.io/en/stable/canonical-urls.html
+    -->
+    <link rel="canonical" href="{{ canonical_url|e }}{{ canonical_page }}" />
+    {%- endif %}
+
     <link rel="icon" type="image/png" href="{{ pathto('_static', 1) }}/images/favicon.png"/>
     {%- endif %}
 {%- block linktags %}


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

This should add the missing `index.html` for canonical URLs (original issue: https://github.com/crate/tech-writing/issues/417#issuecomment-2066746951). Can we do a demo to test thoroughly before going live? Tested locally, but not sure what happens when RTD is trying to add their own code, could be either ignored or this piece overwritten.

Code is borrowed from https://github.com/readthedocs/readthedocs-sphinx-ext/blob/614109c6ad11eaacbcde1040b908967c80b81eba/readthedocs_ext/_templates/readthedocs-insert.html.tmpl#L4-L19