### PR TITLE
UI: Visually disable annoying "notificatio-pro" component

### DIFF
--- a/src/crate/theme/rtd/crate/static/css/crateio-ng.css
+++ b/src/crate/theme/rtd/crate/static/css/crateio-ng.css
@@ -66,3 +66,9 @@ button.toggle-button {
     right: 0;
   }
 }
+
+
+/* Visually disable annoying "notificatio-pro" component */
+.notificatio-pro {
+  display: none;
+}


### PR DESCRIPTION
## Problem

Recent deliveries of documentation resources include an annoying overlay on the bottom left corner, which is constantly trying to capture attention, by collapsing/fading in and out of the page border.

![image](https://github.com/crate/crate-docs-theme/assets/453543/57bb4ddb-b150-46e2-a437-ea4f4534d14f)
