### PR TITLE
Fix downstream behavior on "not versioned" projects like CrateDB Guide

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ CHANGES
 
 Unreleased
 ----------
+- Fix downstream behavior on "not versioned" projects like CrateDB Guide.
 
 2024/05/06 0.32.0
 -----------------

--- a/src/crate/theme/rtd/conf/__init__.py
+++ b/src/crate/theme/rtd/conf/__init__.py
@@ -208,6 +208,9 @@ def setup(app):
         if html_baseurl is None:
             return
 
+        # A little heuristic to consider a project as "not versioned",
+        # and process it accordingly, when the value of the "version"
+        # setting is empty.
         rtd_language = config["language"]
         rtd_version = config["version"]
         if rtd_version:

--- a/src/crate/theme/rtd/conf/cratedb_guide.py
+++ b/src/crate/theme/rtd/conf/cratedb_guide.py
@@ -32,5 +32,4 @@ url_path = "docs/guide"
 html_baseurl = "https://cratedb.com/%s/" % url_path
 
 # This is a project which is not versioned.
-language = ""
 version = ""


### PR DESCRIPTION
## About

This patch intends to fix a problem introduced with the most recent medium-sized cleanup/refactoring of Crate ./. Sphinx ./. RTD documentation intrinsics.

- GH-489
