### PR TITLE
Fix URLs to GitHub feedback

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ CHANGES
 Unreleased
 ----------
 
+- Fix URLs to GitHub feedback (removed hardcoded `https://cratedb.com/`)
+
 2024/05/07 0.32.1
 -----------------
 - Fix downstream behavior on "not versioned" projects like CrateDB Guide.

--- a/src/crate/theme/rtd/crate/github_feedback_compact.html
+++ b/src/crate/theme/rtd/crate/github_feedback_compact.html
@@ -28,9 +28,9 @@ set source_path = conf_py_path + pagename + suffix
           '<!-- Please do not edit or remove the following information -->'|urlencode }}{{ '%0A '
         }}{{ '%0A'
         }}{{
-          '- Page title: '|urlencode }}{{ title|striptags|urlencode }}{{ '%0A'
+          '- Page title: ' }}{{ title|striptags|urlencode }}{{ '%0A'
         }}{{
-          '- Page URL: https://cratedb.com/'|urlencode }}{{ custom_baseurl|urlencode }}{{ pagename|urlencode }}.html{{ '%0A'
+          '- Page URL: ' }}{{ custom_baseurl|urlencode }}{{ pagename|urlencode }}.html{{ '%0A'
         }}{{
           '- Source: https://'|urlencode }}{{ github_host|default('github.com') }}/{{ github_user }}/{{ github_repo }}/{{ theme_vcs_pageview_mode|default('blob') }}/{{ github_version }}{{ conf_py_path|urlencode }}{{ pagename|urlencode }}{{ suffix }}{{ '%0A'
         }}{{ '%0A'

--- a/src/crate/theme/rtd/crate/github_feedback_full.html
+++ b/src/crate/theme/rtd/crate/github_feedback_full.html
@@ -39,9 +39,9 @@
           '<!--Please do not edit or remove the following information -->'|urlencode }}{{ '%0A '
         }}{{ '%0A'
         }}{{
-          '- Page title: '|urlencode }}{{ title|striptags|urlencode }}{{ '%0A'
+          '- Page title: ' }}{{ title|striptags|urlencode }}{{ '%0A'
         }}{{
-          '- Page URL: https://cratedb.com/'|urlencode }}{{ custom_baseurl|urlencode }}{{ pagename|urlencode }}.html{{ '%0A'
+          '- Page URL: ' }}{{ custom_baseurl|urlencode }}{{ pagename|urlencode }}.html{{ '%0A'
         }}{{
           '- Source: https://'|urlencode }}{{ github_host|default('github.com') }}/{{ github_user }}/{{ github_repo }}/{{ theme_vcs_pageview_mode|default('blob') }}/{{ github_version }}{{ conf_py_path|urlencode }}{{ pagename|urlencode }}{{ suffix }}{{ '%0A'
         }}{{ '%0A'


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

As the title suggests, this fixes URLs to GitHub feedback (removed hardcoded `https://cratedb.com/`)