### PR TITLE
Add documentation project `sqlalchemy-cratedb`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ CHANGES
 
 Unreleased
 ----------
+- Added documentation project ``sqlalchemy-cratedb``
 
 2024/05/28 0.32.3
 -----------------

--- a/src/crate/theme/rtd/conf/__init__.py
+++ b/src/crate/theme/rtd/conf/__init__.py
@@ -111,6 +111,7 @@ intersphinx_mapping = {
     'crate-operator': ('https://crate-operator.readthedocs.io/en/latest/', None),
     'crate-pdo': ('https://cratedb.com/docs/pdo/en/latest/', None),
     'crate-python': ('https://cratedb.com/docs/python/en/latest/', None),
+    'sqlalchemy-cratedb': ('https://cratedb.com/docs/sqlalchemy-cratedb/', None),
 
     # CrateDB Cloud
     'cloud': ('https://cratedb.com/docs/cloud/en/latest/', None),

--- a/src/crate/theme/rtd/conf/sqlalchemy_cratedb.py
+++ b/src/crate/theme/rtd/conf/sqlalchemy_cratedb.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; -*-
+#
+# Licensed to Crate (https://crate.io) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  Crate licenses
+# this file to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# However, if you have executed another commercial license agreement
+# with Crate these terms will supersede the license and you may use the
+# software solely pursuant to the terms of the relevant commercial agreement.
+
+
+from crate.theme.rtd.conf import *
+
+# If you update the `project` value here, you must update it in the
+# `src/crate/theme/rtd/crate/sidebartoc.html` file or else Sphinx will not
+# expand the sidebar TOC for this project.
+project = u"SQLAlchemy Dialect"
+html_title = project
+
+url_path = "docs/sqlalchemy-cratedb"
+html_baseurl = "https://cratedb.com/%s/" % url_path
+
+# This is a project which is not versioned.
+version = ""

--- a/src/crate/theme/rtd/crate/sidebartoc.html
+++ b/src/crate/theme/rtd/crate/sidebartoc.html
@@ -60,7 +60,7 @@
   {%
   set driver_projects = [
     'CrateDB: Clients and Tools',
-    'CrateDB JDBC', 'CrateDB DBAL', 'CrateDB PDO', 'CrateDB Python', 'CrateDB Npgsql'
+    'CrateDB JDBC', 'CrateDB DBAL', 'CrateDB PDO', 'CrateDB Python', 'SQLAlchemy Dialect', 'CrateDB Npgsql'
   ]
   %}
   {% if project in driver_projects %}
@@ -104,6 +104,14 @@
       </li>
       {% else %}
       <li class="navleft-item"><a href="/docs/python/">Python</a></li>
+      {% endif %}
+      {% if project == 'SQLAlchemy Dialect' %}
+      <li class="current">
+        <a class="current-active" href="{{ pathto(master_doc) }}">SQLAlchemy</a>
+        {{ toctree(maxdepth=3|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
+      </li>
+      {% else %}
+      <li class="navleft-item"><a href="/docs/sqlalchemy-cratedb/">SQLAlchemy</a></li>
       {% endif %}
       {% if project == 'CrateDB Npgsql' %}
       <li class="current">


### PR DESCRIPTION
## About
The [CrateDB SQLAlchemy dialect](https://github.com/crate-workbench/sqlalchemy-cratedb) needs more love, so it was separated from the [DBAPI HTTP driver](https://github.com/crate/crate-python). This patch intends to accompany the migration, by slotting the documentation into the documentation tree.

## Details
The new canonical package for the SQLAlchemy CrateDB dialect on PyPI is:

> https://pypi.org/project/sqlalchemy-cratedb/

/cc @matriv, @surister
