### PR TITLE
Menu item for top-level documentation home

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ CHANGES
 Unreleased
 ----------
 - CSS: Adjusted inner alignment being off for cards with links
+- Home: Added new top-level landing page, indexing the main docs entrypoints
 
 2024/06/27 0.33.0
 -----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ CHANGES
 
 Unreleased
 ----------
+- CSS: Adjusted inner alignment being off for cards with links
 
 2024/06/27 0.33.0
 -----------------

--- a/src/crate/theme/rtd/crate/sidebartoc.html
+++ b/src/crate/theme/rtd/crate/sidebartoc.html
@@ -9,6 +9,13 @@
 
   {% else %}
 
+  <!-- Home. -->
+  {% if project == 'CrateDB: Guide' and pagename == 'home/index' %}
+    <li class="navleft-item current"><a class="current-active" href="/docs/guide/home/">Docs Home</a></li>
+  {% else %}
+    <li class="navleft-item"><a href="/docs/guide/home/">Docs Home</a></li>
+  {% endif %}
+
   <!-- Section A. -->
   {% if project == 'CrateDB Cloud' %}
     <li class="current">
@@ -19,7 +26,7 @@
     <li class="navleft-item"><a href="/docs/cloud/">CrateDB Cloud</a></li>
   {% endif %}
 
-  {% if project == 'CrateDB: Guide' %}
+  {% if project == 'CrateDB: Guide' and pagename != 'home/index' %}
     <li class="current">
       <a class="current-active" href="{{ pathto(master_doc) }}">Guides and Tutorials</a>
       {{ toctree(maxdepth=3|toint, collapse=True, includehidden=theme_globaltoc_includehidden|tobool) }}

--- a/src/crate/theme/rtd/crate/static/css/crateio-ng.css
+++ b/src/crate/theme/rtd/crate/static/css/crateio-ng.css
@@ -78,3 +78,9 @@ button.toggle-button {
 .notificatio-pro {
   display: none;
 }
+
+
+/* Cards with Links */
+.sd-hide-link-text {
+  height: 0;
+}


### PR DESCRIPTION
## About
Add menu item for new top-level landing page, indexing the main docs entrypoints.

## References
- https://github.com/crate/cratedb-guide/pull/94