### PR TITLE
NG: Update Furo styles and scripts to version 2024.05.06

### DIFF
--- a/src/crate/theme/rtd/crate/static/vendor/furo/scripts/furo.js
+++ b/src/crate/theme/rtd/crate/static/vendor/furo/scripts/furo.js
@@ -141,7 +141,7 @@ function setupScrollSpy() {
     navClass: "scroll-current",
     offset: () => {
       let rem = parseFloat(getComputedStyle(document.documentElement).fontSize);
-      return header.getBoundingClientRect().height + 0.5 * rem + 1;
+      return header.getBoundingClientRect().height + 2.5 * rem + 1;
     },
   });
 }

--- a/src/crate/theme/rtd/crate/static/vendor/furo/scripts/gumshoe-patched.js
+++ b/src/crate/theme/rtd/crate/static/vendor/furo/scripts/gumshoe-patched.js
@@ -20,8 +20,8 @@
   typeof global !== "undefined"
     ? global
     : typeof window !== "undefined"
-    ? window
-    : this,
+      ? window
+      : this,
   function (window) {
     "use strict";
 

--- a/src/crate/theme/rtd/crate/static/vendor/furo/styles/_scaffold.sass
+++ b/src/crate/theme/rtd/crate/static/vendor/furo/styles/_scaffold.sass
@@ -17,6 +17,8 @@
 // causing the content to stutter horizontally between taller-than-viewport and
 // not-taller-than-viewport pages.
 
+$icon-size: 1.25rem
+
 html
   overflow-x: hidden
   overflow-y: scroll
@@ -43,6 +45,22 @@ body
   height: 100%
   color: var(--color-foreground-primary)
   background: var(--color-background-primary)
+
+.skip-to-content
+  position: fixed
+  padding: 1rem
+  border-radius: 1rem
+  left: 0.25rem
+  top: 0.25rem
+  z-index: 40
+  background: var(--color-background-primary)
+  color: var(--color-foreground-primary)
+
+  transform: translateY(-200%)
+  transition: transform 300ms ease-in-out
+
+  &:focus-within
+    transform: translateY(0%)
 
 article
   color: var(--color-content-foreground)
@@ -187,8 +205,8 @@ article
 
 .theme-toggle svg
   vertical-align: middle
-  height: 1rem
-  width: 1rem
+  height: $icon-size
+  width: $icon-size
   color: var(--color-foreground-primary)
   display: none
 
@@ -205,8 +223,8 @@ article
 
   .icon
     color: var(--color-foreground-secondary)
-    height: 1rem
-    width: 1rem
+    height: $icon-size
+    width: $icon-size
 
 .toc-header-icon, .nav-overlay-icon
   // for when we set display: flex
@@ -225,10 +243,11 @@ article
   margin-bottom: 1rem
   gap: 0.5rem
 
-  .edit-this-page svg
-    color: inherit
-    height: 1rem
-    width: 1rem
+  .edit-this-page, .view-this-page
+    svg
+      color: inherit
+      height: $icon-size
+      width: $icon-size
 
 .sidebar-toggle
   position: absolute
@@ -385,12 +404,12 @@ article
 
   .nav-overlay-icon .icon,
   .theme-toggle svg
-    height: 1.25rem
-    width: 1.25rem
+    height: $icon-size
+    width: $icon-size
 
   // Add a scroll margin for the content
   :target
-    scroll-margin-top: var(--header-height)
+    scroll-margin-top: calc(var(--header-height) + 2.5rem)
 
   // Show back-to-top below the header
   .back-to-top

--- a/src/crate/theme/rtd/crate/static/vendor/furo/styles/base/_screen-readers.sass
+++ b/src/crate/theme/rtd/crate/static/vendor/furo/styles/base/_screen-readers.sass
@@ -8,6 +8,8 @@
   clip: rect(0,0,0,0) !important
   white-space: nowrap !important
   border: 0 !important
+  color: var(--color-foreground-primary)
+  background: var(--color-background-primary)
 
-\:-moz-focusring
+:-moz-focusring
   outline: auto

--- a/src/crate/theme/rtd/crate/static/vendor/furo/styles/base/_theme.sass
+++ b/src/crate/theme/rtd/crate/static/vendor/furo/styles/base/_theme.sass
@@ -43,8 +43,14 @@ html body .only-dark
 // Theme toggle presentation
 //
 body[data-theme="auto"]
-  .theme-toggle svg.theme-icon-when-auto
+  .theme-toggle svg.theme-icon-when-auto-light
     display: block
+
+  @media (prefers-color-scheme: dark)
+    .theme-toggle svg.theme-icon-when-auto-dark
+      display: block
+    .theme-toggle svg.theme-icon-when-auto-light
+      display: none
 
 body[data-theme="dark"]
   .theme-toggle svg.theme-icon-when-dark

--- a/src/crate/theme/rtd/crate/static/vendor/furo/styles/components/_index.sass
+++ b/src/crate/theme/rtd/crate/static/vendor/furo/styles/components/_index.sass
@@ -1,2 +1,4 @@
+@import "footer"
+@import "search"
 @import "sidebar"
 @import "table_of_contents"

--- a/src/crate/theme/rtd/crate/static/vendor/furo/styles/components/_search.sass
+++ b/src/crate/theme/rtd/crate/static/vendor/furo/styles/components/_search.sass
@@ -1,0 +1,17 @@
+//
+// Search Page Listing
+//
+ul.search
+  padding-left: 0
+  list-style: none
+
+  li
+    padding: 1rem 0
+    border-bottom: 1px solid var(--color-background-border)
+
+//
+// Highlighted by links in search page
+//
+[role=main] .highlighted
+  background-color: var(--color-highlighted-background)
+  color: var(--color-highlighted-text)

--- a/src/crate/theme/rtd/crate/static/vendor/furo/styles/components/_sidebar.sass
+++ b/src/crate/theme/rtd/crate/static/vendor/furo/styles/components/_sidebar.sass
@@ -1,8 +1,6 @@
 // This file contains the styles for the contents of the left sidebar, which
 // contains the navigation tree, logo, search etc.
 
-// Source: https://github.com/pradyunsg/furo/blob/main/src/furo/assets/styles/components/_sidebar.sass
-
 ////////////////////////////////////////////////////////////////////////////////
 // Brand on top of the scrollable tree.
 ////////////////////////////////////////////////////////////////////////////////
@@ -135,6 +133,7 @@
     padding: var(--sidebar-item-spacing-vertical) var(--sidebar-item-spacing-horizontal)
 
     &:hover
+      color: var(--color-sidebar-link-text)
       background: var(--color-sidebar-item-background--hover)
 
     // Add a nice little "external-link" arrow here.

--- a/src/crate/theme/rtd/crate/static/vendor/furo/styles/components/_table_of_contents.sass
+++ b/src/crate/theme/rtd/crate/static/vendor/furo/styles/components/_table_of_contents.sass
@@ -40,11 +40,11 @@
   li
     padding-top: var(--toc-item-spacing-vertical)
 
-    &.scroll-current >.reference
+    &.scroll-current > .reference
       color: var(--color-toc-item-text--active)
       font-weight: bold
 
-  .reference
+  a.reference
     color: var(--color-toc-item-text)
     text-decoration: none
     overflow-wrap: anywhere
@@ -58,4 +58,4 @@
   color: var(--color-problematic)
   background: rgba(255, 0, 0, 0.25)
   &::before
-    content: "ERROR: Adding a table of contents in Furo-based documentation is unnecessary, and does not work well with existing styling.Add a 'this-will-duplicate-information-and-it-is-still-useful-here' class, if you want an escape hatch."
+    content: "ERROR: Adding a table of contents in Furo-based documentation is unnecessary, and does not work well with existing styling. Add a 'this-will-duplicate-information-and-it-is-still-useful-here' class, if you want an escape hatch."

--- a/src/crate/theme/rtd/crate/static/vendor/furo/styles/variables/_fonts.scss
+++ b/src/crate/theme/rtd/crate/static/vendor/furo/styles/variables/_fonts.scss
@@ -10,6 +10,7 @@
     sans-serif, Apple Color Emoji, Segoe UI Emoji;
   --font-stack--monospace: "SFMono-Regular", Menlo, Consolas, Monaco,
     Liberation Mono, Lucida Console, monospace;
+  --font-stack--headings: var(--font-stack);
 
   --font-size--normal: 100%;
   --font-size--small: 87.5%;


### PR DESCRIPTION
## About
@msbt updated to Furo 2024.5.6. Thanks! This patch updates corresponding vendorized styles.

## Preview
https://crate-docs-theme--508.org.readthedocs.build/en/508/

## Howto
In order to update to the most recent sources of Furo, best matching the relevant version in `setup.py`, run this procedure:
```
git clone https://github.com/pradyunsg/furo
cd furo
git checkout 2024.05.06
cd src/furo/assets
cp -r * /path/to/crate-docs-theme/src/crate/theme/rtd/crate/static/vendor/furo/
```
Then, commit the changed files selectively.
