### PR TITLE
Override `word-break` to avoid collapsing `dt`'s by full-width `dd`'s 

### DIFF
--- a/src/crate/theme/rtd/crate/static/css/custom.css
+++ b/src/crate/theme/rtd/crate/static/css/custom.css
@@ -1969,3 +1969,8 @@ ul.search li {
 .mb-0 {
   margin-bottom: 0 !important;
 }
+
+/* field-list fix */
+dl.field-list > dt {
+  word-break: normal !important;
+}


### PR DESCRIPTION
What the title says