### PR TITLE
Python: Use Python 3.13 on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
 
@@ -30,7 +31,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.12
+          python-version: '3.12'
 
       - name: Build package
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,9 +21,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest']
-        python-version: ['3.9', '3.12']
+        python-version: ['3.9', '3.13']
 
     steps:
       - uses: actions/checkout@v4

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,7 +10,7 @@ version: 2
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.11"
+    python: "3.12"
   apt_packages:
     - plantuml
 

--- a/README.rst
+++ b/README.rst
@@ -1,16 +1,16 @@
-================
-Crate Docs Theme
-================
+===========================
+CrateDB Documentation Theme
+===========================
 
-|tests| |rtd| |build| |pypi| |python-versions|
+|tests| |rtd| |pypi| |build| |python-versions|
 
 
 About
 =====
 
-A `Sphinx`_ theme for the `Crate documentation`_.
+A `Sphinx`_ theme for the `CrateDB documentation`_.
 
-*Note: This theme is tightly integrated into the Crate.io website and is
+*Note: This theme is tightly integrated into the cratedb.com website and is
 not intended for general use.*
 
 For making changes to the theme, see the `developer docs`_.
@@ -42,16 +42,16 @@ The documentation can include UML diagrams which will be rendered using
 Installation
 ------------
 
-The Crate docs theme is available as a package on `PyPI`_. However, there is no
-need to install it yourself. Crate projects that use the theme should install
+The CrateDB Documentation Theme is available as a package on `PyPI`_. However, there is no
+need to install it yourself. CrateDB projects that use the theme should install
 it automatically.
 
 
 Configuration
 -------------
 
-The Crate.io documentation is composed of multiple separate documentation
-projects, seamlessly interlinked via the Crate docs theme.
+The documentation is composed of multiple separate documentation
+projects, seamlessly interlinked via the CrateDB Documentation Theme.
 
 To use the theme, add this line to your Sphinx ``conf.py`` file::
 
@@ -80,7 +80,7 @@ Looking for more help?
 
 .. _contribution docs: CONTRIBUTING.rst
 .. _Crate.io: https://cratedb.com
-.. _Crate documentation: https://cratedb.com/docs/
+.. _CrateDB documentation: https://cratedb.com/docs/
 .. _developer docs: DEVELOP.rst
 .. _PyPI: https://pypi.python.org/
 .. _Sphinx: http://www.sphinx-doc.org/en/stable/

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Topic :: Software Development :: Documentation",
     ],
     author="Crate.IO GmbH",

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,6 @@ setup(
     keywords="cratedb docs sphinx readthedocs",
     license="Apache License 2.0",
     packages=find_namespace_packages(where="src"),
-    namespace_packages=["crate"],
     package_dir={"": "src"},
     include_package_data=True,
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ README = open(os.path.join(pwd, 'README.rst')).read()
 setup(
     name="crate-docs-theme",
     version=version,
-    description="Crate Docs Theme",
+    description="CrateDB Documentation Theme",
     long_description=README,
     long_description_content_type="text/x-rst",
     classifiers=[
@@ -50,7 +50,7 @@ setup(
     author="Crate.IO GmbH",
     author_email="office@crate.io",
     url="https://github.com/crate/crate-docs-theme",
-    keywords="crate docs sphinx readthedocs",
+    keywords="cratedb docs sphinx readthedocs",
     license="Apache License 2.0",
     packages=find_namespace_packages(where="src"),
     namespace_packages=["crate"],

--- a/src/crate/__init__.py
+++ b/src/crate/__init__.py
@@ -1,3 +1,0 @@
-from pkg_resources import declare_namespace
-
-declare_namespace("crate")


### PR DESCRIPTION
## About
Verify support for Python 3.13.

## Problem
Also, [migrate to use "implicit namespace packages" (PEP 420)](https://github.com/crate/crate-docs-theme/commit/1007fca040) for all people who install the theme alongside a Python package that also uses the `crate` namespace. Otherwise, your Python may trip when importing packages.
```python
ModuleNotFoundError: No module named 'crate.client'
```

See also [Package Discovery and Namespace Package » Finding namespace packages](https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#namespace-packages).