### PR TITLE
Add reference to "All Features" page to primary navigation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ CHANGES
 
 Unreleased
 ----------
+- Added reference to "All Features" page to primary navigation
 
 2024/11/06 0.36.1
 -----------------

--- a/src/crate/theme/rtd/crate/sidebartoc.html
+++ b/src/crate/theme/rtd/crate/sidebartoc.html
@@ -23,6 +23,13 @@
     <li class="navleft-item"><a href="/docs/guide/home/">Docs Home</a></li>
   {% endif %}
 
+  <!-- Features. -->
+  {% if project == 'CrateDB: Guide' and pagename == 'feature/index' %}
+    <li class="navleft-item current"><a class="current-active" href="/docs/guide/feature/">Features</a></li>
+  {% else %}
+    <li class="navleft-item"><a href="/docs/guide/feature/">Features</a></li>
+  {% endif %}
+
   <!-- Section A. -->
   {% if project == 'CrateDB Cloud' %}
     <li class="current">


### PR DESCRIPTION
## About
@kneth signalled interest to increase awareness about the [All Features](https://cratedb.com/docs/guide/feature/) page.
This patch intends to add a reference to the primary navigation prominently.

## Preview
https://crate-docs-theme--547.org.readthedocs.build/en/547/

![image](https://github.com/user-attachments/assets/1bc72948-5c6e-44a9-bf35-d51703fd5ec2)
