### PR TITLE
Chore: Use community.cratedb.com instead of previous crate.io

### DIFF
--- a/src/crate/theme/rtd/crate/sidebartoc.html
+++ b/src/crate/theme/rtd/crate/sidebartoc.html
@@ -154,8 +154,8 @@
 
   <!-- Section D. -->
   <li class="navleft-item border-top"><a target="_blank" href="/support/">Support</a></li>
-  <li class="navleft-item"><a target="_blank" href="https://community.crate.io/">Community</a></li>
-  <li class="navleft-item"><a target="_blank" href="https://community.crate.io/t/overview-of-cratedb-integration-tutorials/1015">Integration Tutorials</a></li>
+  <li class="navleft-item"><a target="_blank" href="https://community.cratedb.com/">Community</a></li>
+  <li class="navleft-item"><a target="_blank" href="https://community.cratedb.com/t/overview-of-cratedb-integration-tutorials/1015">Integration Tutorials</a></li>
   <li class="navleft-item"><a target="_blank" href="https://github.com/crate/crate-sample-apps">Sample Applications</a></li>
   <li class="navleft-item"><a target="_blank" href="https://learn.cratedb.com">Academy</a></li>
 
@@ -169,7 +169,7 @@
 
   {% if project == 'Doing Docs' %}
   <li class="current">
-    <a class="current-active" href="{{ pathto(master_doc) }}">Doing Docs at Crate.io</a>
+    <a class="current-active" href="{{ pathto(master_doc) }}">Doing Docs at CrateDB</a>
     {{ toctree(maxdepth=2|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
   </li>
   {% endif %}


### PR DESCRIPTION
## About
Fix the last link pointing to crate.io here.