### PR TITLE
Chore: Adjust Python version. Trim list of dependencies. Update changelog.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@ CHANGES
 
 Unreleased
 ----------
+- Updated to most recent Furo
+- Added dark theme mode from Furo
+
+Thanks, @msbt.
 
 2024/11/06 0.36.1
 -----------------

--- a/setup.py
+++ b/setup.py
@@ -58,8 +58,6 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        "docutils",
-        "docutils-stubs==0.0.22",
         "furo==2024.8.6",
         "jinja2>=3,<4",
         "myst-parser[linkify]<5",

--- a/setup.py
+++ b/setup.py
@@ -75,5 +75,5 @@ setup(
         "sphinxcontrib-mermaid<2",
         "sphinxcontrib-plantuml>=0.21,<1",
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.9",
 )


### PR DESCRIPTION
## About
- [Python: Set minimum Python version to 3.9](https://github.com/crate/crate-docs-theme/commit/df0f8513c7e14388a2ff9acebf8aa0d078076b0c)
- [Dependencies: Remove docutils package from runtime dependencies](https://github.com/crate/crate-docs-theme/commit/4764da0d2ba4dbcbee9072390b2372c04efe7f83)
- [Update changelog](https://github.com/crate/crate-docs-theme/commit/1fba3b0eb8cc96c9e0f66a48c7cfef1dfad7d6f9)
