### PR TITLE
CrateDB Cloud: Collapse navigation items on `feature/index` page

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ CHANGES
 
 Unreleased
 ----------
+- CrateDB Cloud: Collapse navigation items on ``feature/index`` page
 
 2024/11/26 0.37.1
 -----------------

--- a/src/crate/theme/rtd/crate/sidebartoc.html
+++ b/src/crate/theme/rtd/crate/sidebartoc.html
@@ -27,7 +27,11 @@
   {% if project == 'CrateDB Cloud' %}
     <li class="current">
       <a class="current-active" href="{{ pathto(master_doc) }}">CrateDB Cloud</a>
+      {% if pagename == 'feature/index' %}
+      {{ toctree(maxdepth=0|toint, collapse=True, includehidden=theme_globaltoc_includehidden|tobool) }}
+      {% else %}
       {{ toctree(maxdepth=4|toint, collapse=True, includehidden=theme_globaltoc_includehidden|tobool) }}
+      {% endif %}
     </li>
   {% else %}
     <li class="navleft-item"><a href="/docs/cloud/">CrateDB Cloud</a></li>


### PR DESCRIPTION
## Suggestion
@widmogrod asked at https://github.com/crate/cloud-docs/pull/88#pullrequestreview-2469805836:
> As for the All features page, what I found confusing is the duplication of sub-sections:
> Is there a way to change it, and have all features more like a landing page that just list them?
