### PR TITLE
Fixes for various bugs (scrollbar, focus, cascades), style improvements

### DIFF
--- a/src/crate/theme/rtd/crate/base.html
+++ b/src/crate/theme/rtd/crate/base.html
@@ -113,7 +113,7 @@
   <body>
     {% block body %}
     <script>
-      document.body.dataset.theme = localStorage.getItem("theme") || "auto";
+      document.documentElement.dataset.theme = localStorage.getItem("theme") || "auto";
     </script>
     {% endblock %}
 

--- a/src/crate/theme/rtd/crate/partials/_head_css_variables.html
+++ b/src/crate/theme/rtd/crate/partials/_head_css_variables.html
@@ -12,18 +12,18 @@
 {%- endmacro %}
 
 <style>
-  body {
+  html {
     --color-code-background: #f8f8f8;
     --color-code-foreground: black;
   }
 
   @media not print {
-    body[data-theme="dark"] {
+    html[data-theme="dark"] {
       --color-code-background: #202020;
       --color-code-foreground: #d0d0d0;
     }
     @media (prefers-color-scheme: dark) {
-      body:not([data-theme="light"]) {
+      html:not([data-theme="light"]) {
         --color-code-background: #202020;
         --color-code-foreground: #d0d0d0;
       }

--- a/src/crate/theme/rtd/crate/sidebartoc.html
+++ b/src/crate/theme/rtd/crate/sidebartoc.html
@@ -12,7 +12,7 @@
   <!-- Search. -->
   <li>
     <div class="search-link">
-      <div id="docsearch"></div>
+      <div id="docsearch" style="min-height: 36px; margin-bottom: 20px;"></div>
     </div>
   </li>
 

--- a/src/crate/theme/rtd/crate/static/css/custom.css
+++ b/src/crate/theme/rtd/crate/static/css/custom.css
@@ -1151,20 +1151,6 @@ strong {
   }
 }
 
-@media all and (max-width: 540px) {
-  .notif-bar-enabled {
-    margin-bottom: 180px;
-  }
-
-  dl.field-list {
-    grid-template-columns: none;
-  }
-
-  dl.field-list > dt {
-    margin: 10px 0 5px;
-  }
-}
-
 /* newsletter footer */
 .align-items-center {
   -webkit-box-align: center !important;
@@ -1818,5 +1804,21 @@ html .sd-tab-set > label:hover {
 
   .ais-InstantSearch #pagination {
     overflow-y: scroll;
+  }
+}
+
+@media all and (max-width: 540px) {
+  .notif-bar-enabled {
+    margin-bottom: 180px;
+  }
+
+  dl.field-list {
+    grid-template-columns: none;
+    max-width: 100vw;
+    overflow-y: scroll;
+  }
+
+  dl.field-list > dt {
+    margin: 10px 0 5px;
   }
 }

--- a/src/crate/theme/rtd/crate/static/css/custom.css
+++ b/src/crate/theme/rtd/crate/static/css/custom.css
@@ -9,6 +9,14 @@
   --docsearch-primary-color: #009fc7 !important;
 }
 
+body[data-theme="dark"] {
+  color-scheme: dark;
+}
+
+body[data-theme="light"] {
+  color-scheme: light;
+}
+
 @font-face {
   font-family: "Inter";
   font-style: normal;

--- a/src/crate/theme/rtd/crate/static/css/custom.css
+++ b/src/crate/theme/rtd/crate/static/css/custom.css
@@ -9,11 +9,11 @@
   --docsearch-primary-color: #009fc7 !important;
 }
 
-body[data-theme="dark"] {
+html[data-theme="dark"] {
   color-scheme: dark;
 }
 
-body[data-theme="light"] {
+html[data-theme="light"] {
   color-scheme: light;
 }
 

--- a/src/crate/theme/rtd/crate/static/css/custom.css
+++ b/src/crate/theme/rtd/crate/static/css/custom.css
@@ -1830,4 +1830,8 @@ html .sd-tab-set > label:hover {
   dl.field-list > dt {
     margin: 10px 0 5px;
   }
+
+  #main-content section iframe {
+    max-width: 100%;
+  }
 }

--- a/src/crate/theme/rtd/crate/static/css/custom.css
+++ b/src/crate/theme/rtd/crate/static/css/custom.css
@@ -1776,6 +1776,15 @@ html .sd-tab-set > label:hover {
   color: var(--color-link) !important;
 }
 
+/* tables on mobile */
+@media (max-width: 768px) {
+  #main-content section table {
+    max-width: 100vw;
+    overflow-y: scroll;
+    display: block;
+  }
+}
+
 /* algolia */
 #hits .ais-Hits-item {
   background: var(--color-background-primary);

--- a/src/crate/theme/rtd/crate/static/css/custom.css
+++ b/src/crate/theme/rtd/crate/static/css/custom.css
@@ -1807,6 +1807,10 @@ html .sd-tab-set > label:hover {
   color: var(--color-foreground-primary);
 }
 
+.DocSearch-SearchBar :focus-visible {
+  outline: none;
+}
+
 @media (max-width: 768px) {
   #menu-main-navigation {
     display: none;

--- a/src/crate/theme/rtd/crate/static/js/custom.js
+++ b/src/crate/theme/rtd/crate/static/js/custom.js
@@ -8,7 +8,7 @@ var Cookies = require('js-cookie');
 document.addEventListener('DOMContentLoaded', () => {
     // Function to set the theme
     function setTheme(theme) {
-        document.body.setAttribute('data-theme', theme);
+        document.documentElement.setAttribute('data-theme', theme);
         localStorage.setItem('theme', theme);
     }
 

--- a/src/crate/theme/rtd/crate/static/vendor/furo/scripts/furo.js
+++ b/src/crate/theme/rtd/crate/static/vendor/furo/scripts/furo.js
@@ -75,7 +75,7 @@ function setTheme(mode) {
     mode = "light";
   }
 
-  document.body.dataset.theme = mode;
+  document.documentElement.dataset.theme = mode;
   localStorage.setItem("theme", mode);
 }
 

--- a/src/crate/theme/rtd/crate/static/vendor/furo/styles/base/_theme.sass
+++ b/src/crate/theme/rtd/crate/static/vendor/furo/styles/base/_theme.sass
@@ -21,8 +21,9 @@ html body .only-dark
 // Ignore dark-mode hints if print media.
 @media not print
   // Enable dark-mode, if requested.
-  body[data-theme="dark"]
-    @include colors-dark
+  html[data-theme="dark"]
+    body
+      @include colors-dark
 
     html & .only-light
       display: none !important
@@ -31,8 +32,9 @@ html body .only-dark
 
   // Enable dark mode, unless explicitly told to avoid.
   @media (prefers-color-scheme: dark)
-    body:not([data-theme="light"])
-      @include colors-dark
+    html:not([data-theme="light"])
+      body
+        @include colors-dark
 
       html & .only-light
         display: none !important
@@ -42,7 +44,7 @@ html body .only-dark
 //
 // Theme toggle presentation
 //
-body[data-theme="auto"]
+html[data-theme="auto"]
   .theme-toggle svg.theme-icon-when-auto-light
     display: block
 
@@ -52,10 +54,10 @@ body[data-theme="auto"]
     .theme-toggle svg.theme-icon-when-auto-light
       display: none
 
-body[data-theme="dark"]
+html[data-theme="dark"]
   .theme-toggle svg.theme-icon-when-dark
     display: block
 
-body[data-theme="light"]
+html[data-theme="light"]
   .theme-toggle svg.theme-icon-when-light
     display: block

--- a/src/crate/theme/rtd/crate/static/vendor/furo/styles/variables/_theme.scss
+++ b/src/crate/theme/rtd/crate/static/vendor/furo/styles/variables/_theme.scss
@@ -9,7 +9,7 @@ body {
   @include icons;
   @include admonitions;
   @include default-admonition(#651fff, "abstract");
-  @include default-topic(#14B8A6, "pencil");
+  @include default-topic(#14b8a6, "pencil");
 
   @include colors;
 }
@@ -20,9 +20,12 @@ html body .only-dark {
   display: none !important;
 }
 // Ignore dark-mode hints if print media.
-@media not print {  // Enable dark-mode, if requested.
-  body[data-theme="dark"] {
-    @include colors-dark;
+@media not print {
+  // Enable dark-mode, if requested.
+  html[data-theme="dark"] {
+    body {
+      @include colors-dark;
+    }
 
     html & .only-light {
       display: none !important;
@@ -30,11 +33,13 @@ html body .only-dark {
     .only-dark {
       display: block !important;
     }
-  // Enable dark mode, unless explicitly told to avoid.
+    // Enable dark mode, unless explicitly told to avoid.
   }
   @media (prefers-color-scheme: dark) {
-    body:not([data-theme="light"]) {
-      @include colors-dark;
+    html:not([data-theme="light"]) {
+      body {
+        @include colors-dark;
+      }
 
       html & .only-light {
         display: none !important;
@@ -42,13 +47,13 @@ html body .only-dark {
       .only-dark {
         display: block !important;
       }
-//
-// Theme toggle presentation
-//
+      //
+      // Theme toggle presentation
+      //
     }
   }
 }
-body[data-theme="auto"] {
+html[data-theme="auto"] {
   .theme-toggle svg.theme-icon-when-auto-light {
     display: block;
   }
@@ -61,12 +66,12 @@ body[data-theme="auto"] {
     }
   }
 }
-body[data-theme="dark"] {
+html[data-theme="dark"] {
   .theme-toggle svg.theme-icon-when-dark {
     display: block;
   }
 }
-body[data-theme="light"] {
+html[data-theme="light"] {
   .theme-toggle svg.theme-icon-when-light {
     display: block;
   }

--- a/src/crate/theme/rtd/crate/static/vendor/furo/styles/variables/colors.scss
+++ b/src/crate/theme/rtd/crate/static/vendor/furo/styles/variables/colors.scss
@@ -9,13 +9,13 @@
 //
 // Theme toggle presentation
 //
-body[data-theme="dark"] {
+html[data-theme="dark"] {
   .theme-toggle svg.theme-icon-when-dark {
     display: block;
   }
 }
 
-body[data-theme="light"] {
+html[data-theme="light"] {
   .theme-toggle svg.theme-icon-when-light {
     display: block;
   }


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

- Fix some regressions from Furo (Algolia focus)
- Remove input focus (inherited from Furo)
- CLS fix from Algolia implementation
- Reposition code block (didn't cascade right)
- Add horizontal scrolling to tables on mobile to avoid having layouts wider than the screen
- Keep iframe embeds from having a layout wider than the screen by adding `max-width`
- Fix scrollbar light-colors on Chromium browsers and different modes
- Use `<html>` instead of `<body>` as target for dark/light mode `data-theme` attributes

Demo: https://crate-docs-theme--560.org.readthedocs.build/en/560/
