### PR TITLE
Add MyST-NB for rendering notebooks, and JupySQL for running SQL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@
 .installed.cfg
 .style
 .utils
+*.csv
+*.db
 *.egg-info
 *.lint
 *.pyc

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ CHANGES
 
 Unreleased
 ----------
+- Added `MyST-NB`_, for rendering Jupyter notebooks
+
+.. _MyST-NB: https://myst-nb.readthedocs.io/
 
 2024/12/13 0.37.2
 -----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,9 @@ CHANGES
 Unreleased
 ----------
 - Added `MyST-NB`_, for rendering Jupyter notebooks
+- Added `JupySQL`_, for running SQL in Jupyter/IPython
 
+.. _JupySQL: https://jupysql.ploomber.io/
 .. _MyST-NB: https://myst-nb.readthedocs.io/
 
 2024/12/13 0.37.2

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Unreleased
 ----------
 - Added `MyST-NB`_, for rendering Jupyter notebooks
 - Added `JupySQL`_, for running SQL in Jupyter/IPython
+- MyST-NB: Fixed dark mode for tables in Jupyter Notebooks.
+  Thank you, @surister and @msbt.
 
 .. _JupySQL: https://jupysql.ploomber.io/
 .. _MyST-NB: https://myst-nb.readthedocs.io/

--- a/docs/myst/cell.md
+++ b/docs/myst/cell.md
@@ -1,0 +1,79 @@
+---
+# A Jupyter Notebook written in Markdown.
+# https://myst-nb.readthedocs.io/
+jupytext:
+  text_representation:
+    format_name: myst
+---
+
+(cell)=
+(cells)=
+
+# Cells
+
+Widget elements that are like "editors with output".
+
+:::{note}
+_**Status:** Just written down, no special styling per CSS
+has been applied yet. Contributions are welcome._
+:::
+
+
+## Sphinx
+
+Those are solely based on vanilla [docutils]/[Sphinx] directives
+`code` and `csv-table`, written down in MyST Markdown instead
+of reStructuredText.
+
+:::{code} sql
+SELECT * FROM sometable
+:::
+:::{csv-table}
+:header: >
+:    "schema_name", "table_name", "sum(num_docs)"
+:widths: 15, 10, 30
+
+"doc", "taxi_january", 5929248
+"doc", "taxi_january_bestcompression", 5929248
+"doc", "taxi_january_nocolumnstore_bestcompression", 5929248
+"doc", "taxi_january_nocolumnstore_noindex_bestcompression", 5929248
+"doc", "taxi_january_noindex_bestcompression", 5929248
+"doc", "taxi_january_nocolumnstore", 5929248
+:::
+
+:::{code} bash
+antrl4
+:::
+:::{code} text
+Downloading antlr4-4.13.2-complete.jar
+ANTLR tool needs Java to run; install Java JRE 11 yes/no (default yes)? yes
+Installed Java in /root/.jre/jdk-11.0.24+8-jre; remove that dir to uninstall
+ANTLR Parser Generator  Version 4.13.2
+:::
+
+## IPython
+
+Those are using [MyST-NB],
+actually executing Python code,
+like [doctest] is doing it.
+
+```{code-cell} ipython3
+import sys
+print("this is some stdout")
+print("this is some stderr", file=sys.stderr)
+```
+
+:::{important}
+This actually means the documentation can include Jupyter Notebooks
+now, both using the traditional .ipynb JSON file format, but also
+using the .md file format, enabling [text-based notebooks].
+Enjoy {ref}`notebook-text`.
+:::
+
+
+
+[docutils]: https://www.docutils.org/
+[doctest]: https://docs.python.org/3/library/doctest.html
+[MyST-NB]: https://myst-nb.readthedocs.io/
+[Sphinx]: https://www.sphinx-doc.org/
+[text-based notebooks]: https://myst-nb.readthedocs.io/en/latest/authoring/text-notebooks.html

--- a/docs/myst/notebook-text.md
+++ b/docs/myst/notebook-text.md
@@ -1,0 +1,26 @@
+---
+# A Jupyter Notebook written in Markdown.
+# https://myst-nb.readthedocs.io/
+file_format: mystnb
+---
+
+(notebook-text)=
+
+# Notebook (text-based)
+
+The documentation can include [text-based notebooks] using [MyST-NB],
+effectively bringing Jupyter technologies to Markdown.
+
+```{code-cell} ipython3
+import sys
+print("this is some stdout")
+print("this is some stderr", file=sys.stderr)
+```
+
+:::{tip}
+See also {ref}`notebook-traditional` and {ref}`cells`.
+:::
+
+
+[MyST-NB]: https://myst-nb.readthedocs.io/
+[text-based notebooks]: https://myst-nb.readthedocs.io/en/latest/authoring/text-notebooks.html

--- a/docs/myst/notebook-text.md
+++ b/docs/myst/notebook-text.md
@@ -11,6 +11,8 @@ file_format: mystnb
 The documentation can include [text-based notebooks] using [MyST-NB],
 effectively bringing Jupyter technologies to Markdown.
 
+## Basics
+
 ```{code-cell} ipython3
 import sys
 print("this is some stdout")
@@ -21,6 +23,39 @@ print("this is some stderr", file=sys.stderr)
 See also {ref}`notebook-traditional` and {ref}`cells`.
 :::
 
+## SQL Magics
 
+[JupySQL], the successor of [ipython-sql], enables running SQL in Jupyter/IPython
+via `%sql` and `%%sql` magics.
+
+```{code-cell} ipython3
+# Acquire data.
+!pip --quiet install csvkit
+!curl -s -L -O https://github.com/wireservice/csvkit/raw/refs/heads/master/examples/realdata/acs2012_5yr_population.csv
+!rm -f population.db
+!csvsql --db sqlite:///population.db --insert acs2012_5yr_population.csv
+```
+```{code-cell} ipython3
+# Run query using JupySQL.
+%reload_ext sql
+%sql sqlite:///population.db
+%sql SELECT * FROM acs2012_5yr_population ORDER BY total_population DESC LIMIT 10;
+```
+
+:::{note}
+Here, we are using SQLite, in order not to make `sqlalchemy-cratedb` a
+dependency of the documentation theme. An example using CrateDB can be
+explored at [CrateDB Examples: notebook/jupyter].
+:::
+
+:::{todo}
+Rendering the result table has unfortunate output when using dark mode.
+Please switch to light mode instead.
+:::
+
+
+[CrateDB Examples: notebook/jupyter]: https://github.com/crate/cratedb-examples/tree/main/notebook/jupyter
+[ipython-sql]: https://github.com/catherinedevlin/ipython-sql
+[JupySQL]: https://jupysql.ploomber.io/
 [MyST-NB]: https://myst-nb.readthedocs.io/
 [text-based notebooks]: https://myst-nb.readthedocs.io/en/latest/authoring/text-notebooks.html

--- a/docs/myst/notebook-traditional.ipynb
+++ b/docs/myst/notebook-traditional.ipynb
@@ -15,35 +15,20 @@
    ]
   },
   {
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-01-11T21:09:38.185018Z",
-     "start_time": "2025-01-11T21:09:38.179652Z"
-    }
-   },
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "## Basics"
+  },
+  {
+   "metadata": {},
    "cell_type": "code",
    "source": [
     "import sys\n",
     "print(\"this is some stdout\")\n",
     "print(\"this is some stderr\", file=sys.stderr)"
    ],
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "this is some stdout\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "this is some stderr\n"
-     ]
-    }
-   ],
-   "execution_count": 1
+   "outputs": [],
+   "execution_count": null
   },
   {
    "metadata": {},
@@ -52,6 +37,206 @@
     ":::{tip}\n",
     "See also {ref}`notebook-text` and {ref}`cells`.\n",
     ":::\n"
+   ]
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "## SQL Magics\n",
+    "\n",
+    "[JupySQL], the successor of [ipython-sql], enables running SQL in Jupyter/IPython\n",
+    "via `%sql` and `%%sql` magics.\n",
+    "\n",
+    "[ipython-sql]: https://github.com/catherinedevlin/ipython-sql\n",
+    "[JupySQL]: https://jupysql.ploomber.io/"
+   ]
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-01-11T23:45:54.796565Z",
+     "start_time": "2025-01-11T23:45:47.313805Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "# Acquire data.\n",
+    "!pip --quiet install csvkit\n",
+    "!curl -s -L -O https://github.com/wireservice/csvkit/raw/refs/heads/master/examples/realdata/acs2012_5yr_population.csv\n",
+    "!rm -f population.db\n",
+    "!csvsql --db sqlite:///population.db --insert acs2012_5yr_population.csv"
+   ],
+   "outputs": [],
+   "execution_count": 2
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-01-11T23:45:55.786600Z",
+     "start_time": "2025-01-11T23:45:55.003819Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "# Run query using JupySQL.\n",
+    "%reload_ext sql\n",
+    "%sql sqlite:///population.db\n",
+    "%sql SELECT * FROM acs2012_5yr_population ORDER BY total_population DESC LIMIT 10;"
+   ],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/amo/dev/crate/docs/crate-docs-theme/.venv/lib/python3.12/site-packages/sql/parse.py:338: SyntaxWarning: invalid escape sequence '\\:'\n",
+      "  \"\"\"\n",
+      "/Users/amo/dev/crate/docs/crate-docs-theme/.venv/lib/python3.12/site-packages/sql/parse.py:368: SyntaxWarning: invalid escape sequence '\\:'\n",
+      "  \"\"\"\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Connecting to 'sqlite:///population.db'"
+      ],
+      "text/html": [
+       "<span style=\"None\">Connecting to &#x27;sqlite:///population.db&#x27;</span>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Running query in 'sqlite:///population.db'"
+      ],
+      "text/html": [
+       "<span style=\"None\">Running query in &#x27;sqlite:///population.db&#x27;</span>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "+---------+-------------------------+------------------+-----------------+\n",
+       "|   fips  |           name          | total_population | margin_of_error |\n",
+       "+---------+-------------------------+------------------+-----------------+\n",
+       "| 31055.0 |    Douglas County, NE   |     518271.0     |       0.0       |\n",
+       "| 31109.0 |   Lancaster County, NE  |     286425.0     |       0.0       |\n",
+       "| 31153.0 |     Sarpy County, NE    |     159413.0     |       0.0       |\n",
+       "| 31079.0 |     Hall County, NE     |     58681.0      |       0.0       |\n",
+       "| 31019.0 |    Buffalo County, NE   |     46330.0      |       0.0       |\n",
+       "| 31157.0 | Scotts Bluff County, NE |     36835.0      |       0.0       |\n",
+       "| 31053.0 |     Dodge County, NE    |     36590.0      |       0.0       |\n",
+       "| 31111.0 |    Lincoln County, NE   |     36212.0      |       0.0       |\n",
+       "| 31119.0 |    Madison County, NE   |     34766.0      |       0.0       |\n",
+       "| 31141.0 |    Platte County, NE    |     32195.0      |       0.0       |\n",
+       "+---------+-------------------------+------------------+-----------------+\n",
+       "Truncated to displaylimit of 10."
+      ],
+      "text/html": [
+       "<table>\n",
+       "    <thead>\n",
+       "        <tr>\n",
+       "            <th>fips</th>\n",
+       "            <th>name</th>\n",
+       "            <th>total_population</th>\n",
+       "            <th>margin_of_error</th>\n",
+       "        </tr>\n",
+       "    </thead>\n",
+       "    <tbody>\n",
+       "        <tr>\n",
+       "            <td>31055.0</td>\n",
+       "            <td>Douglas County, NE</td>\n",
+       "            <td>518271.0</td>\n",
+       "            <td>0.0</td>\n",
+       "        </tr>\n",
+       "        <tr>\n",
+       "            <td>31109.0</td>\n",
+       "            <td>Lancaster County, NE</td>\n",
+       "            <td>286425.0</td>\n",
+       "            <td>0.0</td>\n",
+       "        </tr>\n",
+       "        <tr>\n",
+       "            <td>31153.0</td>\n",
+       "            <td>Sarpy County, NE</td>\n",
+       "            <td>159413.0</td>\n",
+       "            <td>0.0</td>\n",
+       "        </tr>\n",
+       "        <tr>\n",
+       "            <td>31079.0</td>\n",
+       "            <td>Hall County, NE</td>\n",
+       "            <td>58681.0</td>\n",
+       "            <td>0.0</td>\n",
+       "        </tr>\n",
+       "        <tr>\n",
+       "            <td>31019.0</td>\n",
+       "            <td>Buffalo County, NE</td>\n",
+       "            <td>46330.0</td>\n",
+       "            <td>0.0</td>\n",
+       "        </tr>\n",
+       "        <tr>\n",
+       "            <td>31157.0</td>\n",
+       "            <td>Scotts Bluff County, NE</td>\n",
+       "            <td>36835.0</td>\n",
+       "            <td>0.0</td>\n",
+       "        </tr>\n",
+       "        <tr>\n",
+       "            <td>31053.0</td>\n",
+       "            <td>Dodge County, NE</td>\n",
+       "            <td>36590.0</td>\n",
+       "            <td>0.0</td>\n",
+       "        </tr>\n",
+       "        <tr>\n",
+       "            <td>31111.0</td>\n",
+       "            <td>Lincoln County, NE</td>\n",
+       "            <td>36212.0</td>\n",
+       "            <td>0.0</td>\n",
+       "        </tr>\n",
+       "        <tr>\n",
+       "            <td>31119.0</td>\n",
+       "            <td>Madison County, NE</td>\n",
+       "            <td>34766.0</td>\n",
+       "            <td>0.0</td>\n",
+       "        </tr>\n",
+       "        <tr>\n",
+       "            <td>31141.0</td>\n",
+       "            <td>Platte County, NE</td>\n",
+       "            <td>32195.0</td>\n",
+       "            <td>0.0</td>\n",
+       "        </tr>\n",
+       "    </tbody>\n",
+       "</table>\n",
+       "<span style=\"font-style:italic;text-align:center;\">Truncated to <a href=\"https://jupysql.ploomber.io/en/latest/api/configuration.html#displaylimit\">displaylimit</a> of 10.</span>"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 3
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    ":::{note}\n",
+    "Here, we are using SQLite, in order not to make `sqlalchemy-cratedb` a\n",
+    "dependency of the documentation theme. An example using CrateDB can be\n",
+    "explored at [CrateDB Examples: notebook/jupyter].\n",
+    ":::\n",
+    "\n",
+    ":::{todo}\n",
+    "Rendering the result table has unfortunate output when using dark mode.\n",
+    "Please switch to light mode instead.\n",
+    ":::\n",
+    "\n",
+    "[CrateDB Examples: notebook/jupyter]: https://github.com/crate/cratedb-examples/tree/main/notebook/jupyter\n"
    ]
   }
  ],

--- a/docs/myst/notebook-traditional.ipynb
+++ b/docs/myst/notebook-traditional.ipynb
@@ -1,0 +1,67 @@
+{
+ "cells": [
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "(notebook-traditional)=\n",
+    "\n",
+    "# Notebook (traditional)\n",
+    "\n",
+    "The documentation can include traditional Jupyter Notebooks in .ipynb JSON format.\n",
+    "They are rendered using [MyST-NB].\n",
+    "\n",
+    "[MyST-NB]: https://myst-nb.readthedocs.io/\n"
+   ]
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-01-11T21:09:38.185018Z",
+     "start_time": "2025-01-11T21:09:38.179652Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "import sys\n",
+    "print(\"this is some stdout\")\n",
+    "print(\"this is some stderr\", file=sys.stderr)"
+   ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "this is some stdout\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "this is some stderr\n"
+     ]
+    }
+   ],
+   "execution_count": 1
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    ":::{tip}\n",
+    "See also {ref}`notebook-text` and {ref}`cells`.\n",
+    ":::\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "name": "python3",
+   "language": "python",
+   "display_name": "Python 3 (ipykernel)"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/docs/rst/cell.rst
+++ b/docs/rst/cell.rst
@@ -1,0 +1,6 @@
+#####
+Cells
+#####
+
+This is just a placeholder.
+See Markdown variant at :ref:`cells`.

--- a/docs/rst/notebook-text.rst
+++ b/docs/rst/notebook-text.rst
@@ -1,0 +1,6 @@
+#####################
+Notebook (text-based)
+#####################
+
+There are no Jupyter Notebooks in reStructuredText format.
+See :ref:`notebook-text` for a Markdown variant instead.

--- a/docs/rst/notebook-traditional.ipynb
+++ b/docs/rst/notebook-traditional.ipynb
@@ -1,0 +1,23 @@
+{
+ "cells": [
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "# Notebook (traditional)\n",
+    "\n",
+    "This is just a placeholder.\n",
+    "See {ref}`notebook-traditional` instead."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "name": "python3",
+   "language": "python",
+   "display_name": "Python 3 (ipykernel)"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
     install_requires=[
         "furo==2024.8.6",
         "jinja2>=3,<4",
+        "myst-nb<1.2",
         "myst-parser[linkify]<5",
         "sphinx>=7.1,<9",
         "sphinx-basic-ng==1.0.0b2",

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
     install_requires=[
         "furo==2024.8.6",
         "jinja2>=3,<4",
+        "jupysql<0.11",
         "myst-nb<1.2",
         "myst-parser[linkify]<5",
         "sphinx>=7.1,<9",

--- a/src/crate/theme/rtd/conf/__init__.py
+++ b/src/crate/theme/rtd/conf/__init__.py
@@ -33,7 +33,7 @@ exclude_patterns = [".*", "*.lint", "README.rst", "requirements.txt"]
 exclude_trees = ["pyenv", "tmp", "out", "parts", "clients", "eggs"]
 
 extensions = [
-    "myst_parser",
+    "myst_nb",
     "sphinx_copybutton",
     "sphinx_design",
     "sphinx_design_elements",

--- a/src/crate/theme/rtd/conf/__init__.py
+++ b/src/crate/theme/rtd/conf/__init__.py
@@ -196,6 +196,9 @@ myst_enable_extensions = [
     "tasklist",
 ]
 
+# -- Options for MyST-NB ----------------------------------------------
+nb_execution_raise_on_error = True
+
 
 def setup(app):
 

--- a/src/crate/theme/rtd/crate/static/css/custom.css
+++ b/src/crate/theme/rtd/crate/static/css/custom.css
@@ -1843,3 +1843,14 @@ html .sd-tab-set > label:hover {
     max-width: 100%;
   }
 }
+
+/*
+Fix dark mode for tables in Jupyter Notebooks rendered by MyST-NB.
+https://github.com/crate/crate-docs-theme/pull/566
+*/
+div.cell_output table {
+  color: var(--color-content-foreground);
+}
+div.cell_output tbody tr:nth-child(2n+1) {
+  background: var(--color-background-hover);
+}


### PR DESCRIPTION
## About
The documentation can now include traditional Jupyter Notebooks in .ipynb format, as well as [text-based notebooks](https://myst-nb.readthedocs.io/en/latest/authoring/text-notebooks.html) written in Markdown, per [MyST-NB].

By streamlining running SQL and plotting large datasets in Jupyter Notebooks, CrateDB can provide details closer to [what others are offering](https://docs.arangodb.com/stable/arangograph/notebooks/), per [JupySQL].

## Details
The patch adds two addons to the documentation stack.

- [MyST-NB] is a gateway from Markdown to IPython/Jupyter: https://github.com/crate/crate-docs-theme/issues/449

- [JupySQL] is a gateway from SQL to IPython/Jupyter via `%sql`, `%%sql`, and `%sqlplot` magics: https://github.com/crate/tech-writing/issues/415

## Preview
- [Notebook (traditional)](https://crate-docs-theme--566.org.readthedocs.build/en/566/myst/notebook-traditional.html) ([source](https://github.com/crate/crate-docs-theme/blob/myst-nb/docs/myst/notebook-traditional.ipynb?plain=1))
- [Notebook (text-based)](https://crate-docs-theme--566.org.readthedocs.build/en/566/myst/notebook-text.html) ([source](https://github.com/crate/crate-docs-theme/blob/myst-nb/docs/myst/notebook-text.md?plain=1))
- [Cells](https://crate-docs-theme--566.org.readthedocs.build/en/566/myst/cell.html) ([source](https://github.com/crate/crate-docs-theme/blob/myst-nb/docs/myst/cell.md?plain=1))


/cc @karynzv, @hlcianfagna, @hammerhead, @wierdvanderhaar, @ckurze, @msbt, @WalBeh, @simonprickett 

[JupySQL]: https://jupysql.ploomber.io/
[MyST-NB]: https://myst-nb.readthedocs.io/