### PR TITLE
Add `oEmbedPy` and `sphinxcontrib-youtube` for embedding videos

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,9 +9,13 @@ Unreleased
 - Added `JupySQL`_, for running SQL in Jupyter/IPython
 - MyST-NB: Fixed dark mode for tables in Jupyter Notebooks.
   Thank you, @surister and @msbt.
+- Added `oEmbedPy`_ and `sphinxcontrib-youtube`_ for embedding
+  videos from YouTube, Vimeo, and more
 
 .. _JupySQL: https://jupysql.ploomber.io/
 .. _MyST-NB: https://myst-nb.readthedocs.io/
+.. _oembedpy: https://oembedpy.readthedocs.io/
+.. _sphinxcontrib-youtube: https://sphinxcontrib-youtube.readthedocs.io/
 
 2024/12/13 0.37.2
 -----------------

--- a/docs/myst/notebook-text.md
+++ b/docs/myst/notebook-text.md
@@ -53,6 +53,16 @@ Rendering the result table has unfortunate output when using dark mode.
 Please switch to light mode instead.
 :::
 
+## Video embeds
+
+Sometimes it is needed for optimal information conveyance, or just for
+entertainment purposes: Notebooks can have video embeds, too.
+
+:::{youtube} YE7VzlLtp-4
+:width: 480
+:height: 320
+:::
+
 
 [CrateDB Examples: notebook/jupyter]: https://github.com/crate/cratedb-examples/tree/main/notebook/jupyter
 [ipython-sql]: https://github.com/catherinedevlin/ipython-sql

--- a/docs/myst/notebook-traditional.ipynb
+++ b/docs/myst/notebook-traditional.ipynb
@@ -238,6 +238,21 @@
     "\n",
     "[CrateDB Examples: notebook/jupyter]: https://github.com/crate/cratedb-examples/tree/main/notebook/jupyter\n"
    ]
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "## Video embeds\n",
+    "\n",
+    "Sometimes it is needed for optimal information conveyance, or just for\n",
+    "entertainment purposes: Notebooks can have video embeds, too.\n",
+    "\n",
+    ":::{youtube} YE7VzlLtp-4\n",
+    ":width: 480\n",
+    ":height: 320\n",
+    ":::"
+   ]
   }
  ],
  "metadata": {

--- a/docs/myst/video.md
+++ b/docs/myst/video.md
@@ -1,0 +1,41 @@
+# Videos
+
+Videos, for example from YouTube or Vimeo, can be embedded using inline
+HTML, [sphinxcontrib-youtube], or [oembedpy].
+
+## Inline HTML
+
+This uses a basic `<iframe ...></iframe>` HTML markup, just written down
+into the Markdown file. Voilà.
+
+<iframe width="480" height="320" src="https://www.youtube-nocookie.com/embed/YE7VzlLtp-4" title="Big Buck Bunny" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+
+## sphinxcontrib-youtube
+
+This uses the `youtube` directive provided by `sphinxcontrib-youtube`.
+
+:::{youtube} YE7VzlLtp-4
+:width: 480
+:height: 320
+:::
+
+## oembedpy
+
+This uses the `oembed` directive provided by `oembedpy`.
+
+:::{oembed} https://www.youtube.com/watch?v=YE7VzlLtp-4
+:maxwidth: 480
+:maxheight: 320
+:::
+
+:::{tip}
+[oEmbedPy], as the name suggests, can render [oEmbed] information provided
+by any HTML page, for example Bluesky, Reddit, Twitter/X, and many more.
+Registered oEmbed providers can be explored per [providers.json].
+:::
+
+
+[oEmbed]: https://oembed.com/
+[oembedpy]: https://oembedpy.readthedocs.io/
+[providers.json]: https://oembed.com/providers.json
+[sphinxcontrib-youtube]: https://sphinxcontrib-youtube.readthedocs.io/

--- a/docs/rst/video.rst
+++ b/docs/rst/video.rst
@@ -1,0 +1,46 @@
+######
+Videos
+######
+
+Videos, for example from YouTube or Vimeo, can be embedded using inline
+HTML, `sphinxcontrib-youtube`_, or `oembedpy`_.
+
+Inline HTML
+===========
+
+This uses a basic ``<iframe ...></iframe>`` HTML markup, just written down
+into the Markdown file. Voilà.
+
+.. raw:: html
+
+    <iframe width="480" height="320" src="https://www.youtube-nocookie.com/embed/YE7VzlLtp-4" title="Big Buck Bunny" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+
+sphinxcontrib-youtube
+=====================
+
+This uses the ``youtube`` directive provided by ``sphinxcontrib-youtube``.
+
+.. youtube:: YE7VzlLtp-4
+    :width: 480
+    :height: 320
+
+oembedpy
+========
+
+This uses the ``oembed`` directive provided by ``oembedpy``.
+
+.. oembed:: https://www.youtube.com/watch?v=YE7VzlLtp-4
+    :maxwidth: 480
+    :maxheight: 320
+
+.. tip::
+
+    `oEmbedPy`_, as the name suggests, can render `oEmbed`_ information provided
+    by any HTML page, for example Bluesky, Reddit, Twitter/X, and many more.
+    Registered oEmbed providers can be explored per `providers.json`_.
+
+
+.. _oEmbed: https://oembed.com/
+.. _oembedpy: https://oembedpy.readthedocs.io/
+.. _providers.json: https://oembed.com/providers.json
+.. _sphinxcontrib-youtube: https://sphinxcontrib-youtube.readthedocs.io/

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup(
         "jupysql<0.11",
         "myst-nb<1.2",
         "myst-parser[linkify]<5",
+        "oembedpy<0.8",
         "sphinx>=7.1,<9",
         "sphinx-basic-ng==1.0.0b2",
         "sphinx-copybutton>=0.3.1,<1",
@@ -74,6 +75,7 @@ setup(
         "sphinxext.opengraph>=0.4,<1",
         "sphinxcontrib-mermaid<2",
         "sphinxcontrib-plantuml>=0.21,<1",
+        "sphinxcontrib-youtube<2",
     ],
     python_requires=">=3.9",
 )

--- a/src/crate/theme/rtd/conf/__init__.py
+++ b/src/crate/theme/rtd/conf/__init__.py
@@ -34,6 +34,7 @@ exclude_trees = ["pyenv", "tmp", "out", "parts", "clients", "eggs"]
 
 extensions = [
     "myst_nb",
+    "oembedpy.ext.sphinx",
     "sphinx_copybutton",
     "sphinx_design",
     "sphinx_design_elements",
@@ -47,6 +48,7 @@ extensions = [
     "sphinx.ext.graphviz",
     "sphinxcontrib.mermaid",
     "sphinxcontrib.plantuml",
+    "sphinxcontrib.youtube",
     "sphinxext.opengraph",
 ]
 


### PR DESCRIPTION
## About
Sphinx pages and Jupyter Notebooks can have video embeds, too.

## Details.
1. There was a question in the audience about whether Sphinx/MyST-NB can display videos from YouTube embedded into the Jupyter Notebook at hand.

2. We started embedding videos on the [CrateDB Guide](https://cratedb.com/docs/guide/) already, but only used inline HTML up until now.

This patch intends to make it proper, by adding relevant Sphinx plugins [oEmbedPy] and [sphinxcontrib-youtube] to the stack.

## Preview
- Traditional page: [myst/video.html](https://crate-docs-theme--568.org.readthedocs.build/en/568/myst/video.html)
- Traditional Jupyter Notebook: [myst/notebook-traditional.html#video-embeds](https://crate-docs-theme--568.org.readthedocs.build/en/568/myst/notebook-traditional.html#video-embeds)
- Text-based Jupyter Notebook: [myst/notebook-text.html#video-embeds](https://crate-docs-theme--568.org.readthedocs.build/en/568/myst/notebook-text.html#video-embeds)

## References
- https://github.com/crate/crate-docs-theme/pull/566

[oEmbedPy]: https://oembedpy.readthedocs.io/
[sphinxcontrib-youtube]: https://sphinxcontrib-youtube.readthedocs.io/

/cc @simonprickett 