### PR TITLE
CI: Use `uv` package and project manager on GHA and RTD

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,8 +31,17 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.13'
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          cache-dependency-glob: |
+            setup.py
+          enable-cache: true
+          version: "latest"
 
       - name: Build package
         run: |
+          alias pip="uv pip"
           make build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,6 +34,15 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          cache-dependency-glob: |
+            setup.py
+          cache-suffix: ${{ matrix.python-version }}
+          enable-cache: true
+          version: "latest"
+
       - name: Install PlantUML on Linux
         if: matrix.os == 'ubuntu-latest'
         run: |
@@ -46,4 +55,5 @@ jobs:
 
       - name: Build docs
         run: |
+          alias pip="uv pip"
           cd docs && make check

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,22 +10,36 @@ version: 2
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.12"
+    python: "3.13"
   apt_packages:
     - plantuml
 
-  # Bundle assets, because `pip install --editable=.` does not do it.
   jobs:
+
+    # Install `uv`.
+    # https://docs.readthedocs.io/en/stable/build-customization.html#install-dependencies-with-uv
+    create_environment:
+      - asdf plugin add uv
+      - asdf install uv latest
+      - asdf global uv latest
+      - uv venv
+
+    # Install dependencies using `uv`.
+    install:
+      - uv pip install -r docs/requirements.txt
+
+    # Bundle assets, because `pip install --editable=.` does not do it.
     pre_build:
       - make bundle-develop
       - cd docs; make bundle-assets
+
+    # Invoke the build also using `uv`.
+    build:
+      html:
+        - uv run sphinx-build -T -b html docs $READTHEDOCS_OUTPUT/html
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   builder: html
   configuration: docs/conf.py
   fail_on_warning: true
-
-python:
-  install:
-    - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-# Install the local crate-docs-theme package by specifying parent directory,
-# because `pip` is run from there.
+# Install the `crate-docs-theme` package from the local working tree
+# in editable mode. `pip` is invoked from the root directory.
 --editable=.


### PR DESCRIPTION
## About
Add the `uv` program to the toolbox, in this case to speed up documentation rebuilds, both on GHA and RTD.

## Details
`uv` is very versatile, and provides better support to work with virtualenvs in different situations, unique support for one-off scripts with inline dependencies, and much more.

## References
- https://docs.astral.sh/uv/
- https://docs.readthedocs.io/en/stable/build-customization.html#install-dependencies-with-uv
- https://github.com/readthedocs/readthedocs.org/issues/11289
- https://github.com/astral-sh/uv/issues/10941
