### PR TITLE
Docs: oEmbed and Video

### DIFF
--- a/docs/myst/oembed.md
+++ b/docs/myst/oembed.md
@@ -1,0 +1,38 @@
+(oembed-md)=
+
+# oEmbed widgets
+
+
+## About
+
+[oEmbed] is a format for allowing an embedded representation of a URL on
+third party sites. The simple API allows a website to display embedded
+content (such as photos or videos) when a user posts a link to that
+resource, without having to parse the resource directly.
+
+Client-side implementations of oEmbed, like [oEmbedPy], can render
+[oEmbed] information provided by any HTML page, for example Bluesky,
+Reddit, Twitter/X, and many more. Registered oEmbed providers can be
+explored per [providers.json].
+
+
+## Examples
+
+### Bluesky
+:::{oembed} https://bsky.app/profile/simonprickett.dev/post/3lgizsidy722u
+:::
+
+### Twitter/X
+:::{oembed} https://x.com/simon_prickett/status/1882858717571641581
+:::
+
+### YouTube
+:::{oembed} https://www.youtube.com/watch?v=YE7VzlLtp-4
+:maxwidth: 480
+:maxheight: 320
+:::
+
+
+[oEmbed]: https://oembed.com/
+[oEmbedPy]: https://oembedpy.readthedocs.io/
+[providers.json]: https://oembed.com/providers.json

--- a/docs/myst/video.md
+++ b/docs/myst/video.md
@@ -1,7 +1,7 @@
 # Videos
 
 Videos, for example from YouTube or Vimeo, can be embedded using inline
-HTML, [sphinxcontrib-youtube], or [oembedpy].
+HTML, [sphinxcontrib-youtube], or [oEmbedPy].
 
 ## Inline HTML
 
@@ -12,11 +12,16 @@ into the Markdown file. Voilà.
 
 ## sphinxcontrib-youtube
 
-This uses the `youtube` directive provided by `sphinxcontrib-youtube`.
+This uses the `youtube` and `vimeo` directives provided by `sphinxcontrib-youtube`.
 
+:::{rubric} YouTube
+:::
 :::{youtube} YE7VzlLtp-4
-:width: 480
-:height: 320
+:::
+
+:::{rubric} Vimeo
+:::
+:::{vimeo} 1084537
 :::
 
 ## oembedpy
@@ -29,13 +34,9 @@ This uses the `oembed` directive provided by `oembedpy`.
 :::
 
 :::{tip}
-[oEmbedPy], as the name suggests, can render [oEmbed] information provided
-by any HTML page, for example Bluesky, Reddit, Twitter/X, and many more.
-Registered oEmbed providers can be explored per [providers.json].
+See {ref}`oembed-md` to learn about all capabilities of the `oembed` directive.
 :::
 
 
-[oEmbed]: https://oembed.com/
-[oembedpy]: https://oembedpy.readthedocs.io/
-[providers.json]: https://oembed.com/providers.json
+[oEmbedPy]: https://oembedpy.readthedocs.io/
 [sphinxcontrib-youtube]: https://sphinxcontrib-youtube.readthedocs.io/

--- a/docs/rst/oembed.rst
+++ b/docs/rst/oembed.rst
@@ -1,0 +1,42 @@
+.. _oembed-rst:
+
+##############
+oEmbed widgets
+##############
+
+=====
+About
+=====
+
+`oEmbed`_ is a format for allowing an embedded representation of a URL on
+third party sites. The simple API allows a website to display embedded
+content (such as photos or videos) when a user posts a link to that
+resource, without having to parse the resource directly.
+
+Client-side implementations of oEmbed, like `oEmbedPy`_, can render
+`oEmbed`_ information provided by any HTML page, for example Bluesky,
+Reddit, Twitter/X, and many more. Registered oEmbed providers can be
+explored per [providers.json].
+
+========
+Examples
+========
+
+Bluesky
+=======
+.. oembed:: https://bsky.app/profile/simonprickett.dev/post/3lgizsidy722u
+
+Twitter/X
+=========
+.. oembed:: https://x.com/simon_prickett/status/1882858717571641581
+
+YouTube
+=======
+.. oembed:: https://www.youtube.com/watch?v=YE7VzlLtp-4
+    :maxwidth: 480
+    :maxheight: 320
+
+
+.. _oEmbed: https://oembed.com/
+.. _oEmbedPy: https://oembedpy.readthedocs.io/
+.. _providers.json: https://oembed.com/providers.json

--- a/docs/rst/video.rst
+++ b/docs/rst/video.rst
@@ -18,11 +18,13 @@ into the Markdown file. Voilà.
 sphinxcontrib-youtube
 =====================
 
-This uses the ``youtube`` directive provided by ``sphinxcontrib-youtube``.
+This uses the ``youtube`` and ``vimeo`` directives provided by ``sphinxcontrib-youtube``.
 
+.. rubric:: YouTube
 .. youtube:: YE7VzlLtp-4
-    :width: 480
-    :height: 320
+
+.. rubric:: Vimeo
+.. vimeo:: 1084537
 
 oembedpy
 ========
@@ -35,12 +37,8 @@ This uses the ``oembed`` directive provided by ``oembedpy``.
 
 .. tip::
 
-    `oEmbedPy`_, as the name suggests, can render `oEmbed`_ information provided
-    by any HTML page, for example Bluesky, Reddit, Twitter/X, and many more.
-    Registered oEmbed providers can be explored per `providers.json`_.
+    See :ref:`oembed-rst` to learn about all capabilities of the ``oembed`` directive.
 
 
-.. _oEmbed: https://oembed.com/
-.. _oembedpy: https://oembedpy.readthedocs.io/
-.. _providers.json: https://oembed.com/providers.json
+.. _oEmbedPy: https://oembedpy.readthedocs.io/
 .. _sphinxcontrib-youtube: https://sphinxcontrib-youtube.readthedocs.io/


### PR DESCRIPTION
- [oEmbed: Add dedicated page](https://github.com/crate/crate-docs-theme/commit/6bc3de432bd95e51d09fc5ba510e7aa0efa812b5) ([preview](https://crate-docs-theme--570.org.readthedocs.build/en/570/myst/oembed.html))
- [Video: Add Vimeo example, and refer to oEmbed page](https://github.com/crate/crate-docs-theme/commit/f95b92d45d806c9aa34169527cc6811b481ac7c7) ([preview](https://crate-docs-theme--570.org.readthedocs.build/en/570/myst/video.html))

Embedding a few messages by @simonprickett. Thanks!