### PR TITLE
Sandbox: Update build environment to use Node.js 22

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Unreleased
   Thank you, @surister and @msbt.
 - Added `oEmbedPy`_ and `sphinxcontrib-youtube`_ for embedding
   videos from YouTube, Vimeo, and more
+- Sandbox: Updated build environment to use Node.js 22
 
 .. _JupySQL: https://jupysql.ploomber.io/
 .. _MyST-NB: https://myst-nb.readthedocs.io/

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ NODEENV  := $(ENV_BIN)/nodeenv
 DIST_DIR := .dist
 PYPIRC   := ~/.pypirc
 
-NODEJS_VERSION := 18.17.0
+NODEJS_VERSION := 22.13.1
 
 # Default target
 .PHONY: help


### PR DESCRIPTION
## About
Bump sandbox from Node.js 18 to Node.js 22.

## Backlog
_Non-blocking._

@msbt: The `make bundle-develop` step bears a few deprecation warnings (see [RTD build 26963098](https://readthedocs.org/projects/crate-docs-theme/builds/26963098/)). It is probably on Furo to fix most of them?
