### PR TITLE
CSS: Add hover color for tr overrides from #566

### DIFF
--- a/src/crate/theme/rtd/crate/static/css/custom.css
+++ b/src/crate/theme/rtd/crate/static/css/custom.css
@@ -1851,6 +1851,11 @@ https://github.com/crate/crate-docs-theme/pull/566
 div.cell_output table {
   color: var(--color-content-foreground);
 }
-div.cell_output tbody tr:nth-child(2n+1) {
+div.cell_output tbody tr:nth-child(odd) {
   background: var(--color-background-hover);
+}
+
+div.cell_output tbody tr:nth-child(odd):hover,
+div.cell_output tbody tr:nth-child(even):hover {
+  background: rgba(66, 165, 245, 0.2);
 }


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

There's no hover effect on the odd `tr`s, this fixes it (original PR https://github.com/crate/crate-docs-theme/pull/566 - https://crate-docs-theme--566.org.readthedocs.build/en/566/myst/notebook-traditional.html for non-working demo).
