### PR TITLE
Chore: Add www.gnu.org to global link checker ignores

### DIFF
--- a/src/crate/theme/rtd/conf/__init__.py
+++ b/src/crate/theme/rtd/conf/__init__.py
@@ -172,6 +172,8 @@ linkcheck_ignore = [
     "https://www.iso.org/obp/ui/.*",
     # 403 Client Error: Forbidden for url
     "https://unsplash.com/.*",
+    # [Errno 101] Network is unreachable
+    "https://www.gnu.org/.*",
 ]
 linkcheck_anchors_ignore_for_url = [
     # Requires JavaScript.


### PR DESCRIPTION
## Problem

www.gnu.org regularly rejects connections on our documentation (re-)builds.

## Details

"It happens more often than not" would be the wrong assessment, but still it's annoying when documentation updates or rebuilds go south on this, and frequency seems to be increasing with gnu.org. Its connectivity displays intermittently flaky, probably due to WAF technologies used to deter knowledge scraping bots, probably aiming to learn and understand the Linux userspace.

```
(performance/inserts/bulk: line  295)       broken    https://www.gnu.org/software/gzip/ - HTTPSConnectionPool(host='www.gnu.org', port=443): Max retries exceeded with url: /software/gzip/ (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7f9e09d492d0>: Failed to establish a new connection: [Errno 101] Network is unreachable'))
(domain/timeseries/generate/cli: line   97) broken    https://www.gnu.org/software/bash/manual/html_node/Shell-Functions.html - HTTPSConnectionPool(host='www.gnu.org', port=443): Max retries exceeded with url: /software/bash/manual/html_node/Shell-Functions.html (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7f9e0a8a5250>: Failed to establish a new connection: [Errno 101] Network is unreachable'))
```

-- https://github.com/crate/cratedb-guide/actions/runs/13716280000/job/38361979485#step:4:1966
