### PR TITLE
Dependencies: Fix oEmbedPy by downgrading to version 0.7

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ CHANGES
 
 Unreleased
 ----------
+- Downgraded oEmbedPy Sphinx plugin to version 0.7, because of `THEME-586`_
+
+.. _THEME-586: https://github.com/crate/crate-docs-theme/issues/586
 
 2025/03/07 0.38.1
 -----------------

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
         "jupysql<0.11",
         "myst-nb<1.3",
         "myst-parser[linkify]<5",
-        "oembedpy<0.9",
+        "oembedpy<0.8",
         "sphinx>=7.1,<9",
         "sphinx-basic-ng==1.0.0b2",
         "sphinx-copybutton>=0.3.1,<1",

--- a/src/crate/theme/rtd/conf/__init__.py
+++ b/src/crate/theme/rtd/conf/__init__.py
@@ -34,7 +34,7 @@ exclude_trees = ["pyenv", "tmp", "out", "parts", "clients", "eggs"]
 
 extensions = [
     "myst_nb",
-    "oembedpy.adapters.sphinx",
+    "oembedpy.ext.sphinx",
     "sphinx_copybutton",
     "sphinx_design",
     "sphinx_design_elements",


### PR DESCRIPTION
## About

The most recent oEmbedPy 0.8 raised errors, so let's downgrade to 0.7.

## References

- https://github.com/crate/crate-docs-theme/issues/586
- https://github.com/attakei/oEmbedPy/issues/9