### PR TITLE
Dependencies: Downgrade to snowballstemmer v2 because v3 is bogus

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ CHANGES
 
 Unreleased
 ----------
+- Dependencies: Downgraded to snowballstemmer v2 because v3 release is bogus
 
 2025/04/07 0.38.4
 -----------------

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
         "myst-nb<1.3",
         "myst-parser[linkify]<5",
         "oembedpy>=0.8.1,<0.9",
+        "snowballstemmer<3",
         "sphinx>=7.1,<9",
         "sphinx-basic-ng==1.0.0b2",
         "sphinx-copybutton>=0.3.1,<1",


### PR DESCRIPTION
## Problem
```python
KeyError: "Stemming algorithm 'porter' not found"
```

## References
- https://github.com/snowballstem/snowball/issues/229
