### PR TITLE
Rename "Docs Home" to "Overview"

### DIFF
--- a/src/crate/theme/rtd/crate/sidebartoc.html
+++ b/src/crate/theme/rtd/crate/sidebartoc.html
@@ -18,9 +18,9 @@
 
   <!-- Home. -->
   {% if project == 'CrateDB: Guide' and pagename == 'home/index' %}
-    <li class="navleft-item current"><a class="current-active" href="/docs/guide/home/">Docs Home</a></li>
+    <li class="navleft-item current"><a class="current-active" href="/docs/guide/home/">Overview</a></li>
   {% else %}
-    <li class="navleft-item"><a href="/docs/guide/home/">Docs Home</a></li>
+    <li class="navleft-item"><a href="/docs/guide/home/">Overview</a></li>
   {% endif %}
 
   <!-- Section A. -->


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Perhaps this is just a personal taste, but I find "Overview" more descriptive than "Docs Home".
