### PR TITLE
Fix favicon HTML

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ CHANGES
 
 Unreleased
 ----------
+- Fixed favicon HTML. Thanks, @michaelkremmel.
 
 2025/05/08 0.38.5
 -----------------

--- a/src/crate/theme/rtd/crate/base.html
+++ b/src/crate/theme/rtd/crate/base.html
@@ -34,7 +34,7 @@
     {%- endblock linktags %}
 
     {# Favicon #}
-    <link rel="shortcut icon" type="image/png" href="{{ pathto('_static', 1) }}/images/favicon.png"/>
+    <link rel="icon" type="image/png" href="{{ pathto('_static', 1) }}/images/favicon.png"/>
    
     {%- endblock site_meta -%}
 


### PR DESCRIPTION
Changed the rel attribute from "shortcut icon" to "icon" to make sure Google can index our favicon. See: https://developers.google.com/search/docs/appearance/favicon-in-search

## Summary of the changes / Why this is an improvement


## Checklist

 - [ ] Link to issue this PR refers to (if applicable): Fixes #???
