### PR TITLE
left nav TOC reduced only have page titles

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,11 @@ CHANGES
 Unreleased
 ----------
 
+- CrateDB Cloud: Removed special handling for the ``feature/index`` page as it
+no longer exists.
+- Updated left navbar TOC to only show titles of pages, but not "subsections" or
+headings within the page itself. That is already done by the right-hand TOC sidebar.
+
 2025/06/11 0.38.6
 -----------------
 - Fixed favicon HTML. Thanks, @michaelkremmel.
@@ -178,7 +183,7 @@ Thanks, @msbt.
 - Removed legacy ``.woff`` font-files
 - Update SQL-99 config (``html_baseurl``, ``url_path``
   and ``canonical_url_path``)
-- Removed ``webflow.js``, artifacts from the abandoned 
+- Removed ``webflow.js``, artifacts from the abandoned
   feedback box and rating system, removed unused css
 - Added "Guides and Tutorials" section
 

--- a/src/crate/theme/rtd/__init__.py
+++ b/src/crate/theme/rtd/__init__.py
@@ -23,7 +23,7 @@
 
 import os
 
-VERSION = (0, 38, 6)
+VERSION = (0, 38, 7)
 
 __version__ = ".".join(str(v) for v in VERSION)
 __version_full__ = __version__

--- a/src/crate/theme/rtd/crate/base.html
+++ b/src/crate/theme/rtd/crate/base.html
@@ -35,7 +35,7 @@
 
     {# Favicon #}
     <link rel="icon" type="image/png" href="{{ pathto('_static', 1) }}/images/favicon.png"/>
-   
+
     {%- endblock site_meta -%}
 
     {% block head_extra %}
@@ -43,7 +43,7 @@
     <link rel="preconnect" href="https://az1nev7cg0-dsn.algolia.net" crossorigin />
     <!-- Algolia stylesheet -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3" />
-  
+
     <!-- Google Tag Manager -->
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
       new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
@@ -51,13 +51,13 @@
       'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
       })(window,document,'script','dataLayer','GTM-WHMDSK');</script>
       <!-- End Google Tag Manager -->
-  
+
     <noscript>
         <style>
             .cr-nojs-hide { display: none; }
         </style>
     </noscript>
-  
+
     {%- if custom_baseurl %}
     {%- set canonical_page = pagename + ".html" %}
     <!--
@@ -138,7 +138,7 @@
         <div class="content-wrapper container">
           <div class="row">
             <div class="col-md-3">
-              <h4>Subscribe to the CrateDB Newsletter now</h4>
+              <h4>Subscribe to the CrateDB Newsletter</h4>
             </div>
             <div class="col-md-9">
               <div class="footer-subs-form">

--- a/src/crate/theme/rtd/crate/sidebartoc.html
+++ b/src/crate/theme/rtd/crate/sidebartoc.html
@@ -27,11 +27,7 @@
   {% if project == 'CrateDB Cloud' %}
     <li class="current">
       <a class="current-active" href="{{ pathto(master_doc) }}">CrateDB Cloud</a>
-      {% if pagename == 'feature/index' %}
-      {{ toctree(maxdepth=0|toint, collapse=True, includehidden=theme_globaltoc_includehidden|tobool) }}
-      {% else %}
-      {{ toctree(maxdepth=4|toint, collapse=True, includehidden=theme_globaltoc_includehidden|tobool) }}
-      {% endif %}
+      {{ toctree(maxdepth=-1|toint, titles_only=True, collapse=True, includehidden=theme_globaltoc_includehidden|tobool) }}
     </li>
   {% else %}
     <li class="navleft-item"><a href="/docs/cloud/">CrateDB Cloud</a></li>
@@ -40,7 +36,7 @@
   {% if project == 'CrateDB: Guide' and pagename != 'home/index' %}
     <li class="current">
       <a class="current-active" href="{{ pathto(master_doc) }}">Guides and Tutorials</a>
-      {{ toctree(maxdepth=4|toint, collapse=True, includehidden=theme_globaltoc_includehidden|tobool) }}
+      {{ toctree(maxdepth=-1|toint, titles_only=True, collapse=True, includehidden=theme_globaltoc_includehidden|tobool) }}
     </li>
   {% else %}
     <li class="navleft-item"><a href="/docs/guide/">Guides and Tutorials</a></li>
@@ -49,7 +45,7 @@
   {% if project == 'CrateDB: Reference' %}
     <li class="current">
       <a class="current-active" href="{{ pathto(master_doc) }}">Reference Manual</a>
-      {{ toctree(maxdepth=3|toint, collapse=True, includehidden=theme_globaltoc_includehidden|tobool) }}
+      {{ toctree(maxdepth=-1|toint, titles_only=True, collapse=True, includehidden=theme_globaltoc_includehidden|tobool) }}
     </li>
   {% else %}
     <li class="navleft-item"><a href="/docs/crate/reference/">Reference Manual</a></li>
@@ -60,7 +56,7 @@
   {% if project == 'CrateDB: Admin UI' %}
   <li class="current border-top">
     <a class="current-active" href="{{ pathto(master_doc) }}">Admin UI</a>
-    {{ toctree(maxdepth=1|toint, collapse=True, includehidden=theme_globaltoc_includehidden|tobool) }}
+    {{ toctree(maxdepth=-1|toint, titles_only=True, collapse=True, includehidden=theme_globaltoc_includehidden|tobool) }}
   </li>
   {% else %}
   <li class="navleft-item border-top"><a href="/docs/crate/admin-ui/">Admin UI</a></li>
@@ -69,7 +65,7 @@
   {% if project == 'CrateDB: Crash CLI' %}
   <li class="current">
     <a class="current-active" href="{{ pathto(master_doc) }}">CrateDB CLI</a>
-    {{ toctree(maxdepth=1|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
+    {{ toctree(maxdepth=-1|toint, titles_only=True, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
   </li>
   {% else %}
   <li class="navleft-item"><a href="/docs/crate/crash/">CrateDB CLI</a></li>
@@ -78,7 +74,7 @@
   {% if project == 'CrateDB Cloud: Croud CLI' %}
   <li class="current">
     <a class="current-active" href="{{ pathto(master_doc) }}">Cloud CLI</a>
-    {{ toctree(maxdepth=1|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
+    {{ toctree(maxdepth=-1|toint, titles_only=True, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
   </li>
   {% else %}
   <li class="navleft-item"><a href="/docs/cloud/cli/">Cloud CLI</a></li>
@@ -94,7 +90,7 @@
   <li class="current">
     {% if project == 'CrateDB: Clients and Tools' %}
       <a class="current-active" href="{{ pathto(master_doc) }}">Drivers and Integrations</a>
-      {{ toctree(maxdepth=3|toint, collapse=True, includehidden=theme_globaltoc_includehidden|tobool) }}
+      {{ toctree(maxdepth=-1|toint, titles_only=True, collapse=True, includehidden=theme_globaltoc_includehidden|tobool) }}
     {% else %}
       <a class="current-active" href="/docs/crate/clients-tools/">Drivers and Integrations</a>
     {% endif %}
@@ -103,7 +99,7 @@
       {% if project == 'CrateDB JDBC' %}
       <li class="current">
         <a class="current-active" href="{{ pathto(master_doc) }}">JDBC</a>
-        {{ toctree(maxdepth=3|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
+        {{ toctree(maxdepth=-1|toint, titles_only=True, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
       </li>
       {% else %}
       <li class="navleft-item"><a href="/docs/jdbc/">JDBC</a></li>
@@ -111,7 +107,7 @@
       {% if project == 'CrateDB DBAL' %}
       <li class="current">
         <a class="current-active" href="{{ pathto(master_doc) }}">PHP DBAL</a>
-        {{ toctree(maxdepth=3|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
+        {{ toctree(maxdepth=-1|toint, titles_only=True, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
       </li>
       {% else %}
       <li class="navleft-item"><a href="/docs/dbal/">PHP DBAL</a></li>
@@ -119,7 +115,7 @@
       {% if project == 'CrateDB PDO' %}
       <li class="current">
         <a class="current-active" href="{{ pathto(master_doc) }}">PHP PDO</a>
-        {{ toctree(maxdepth=3|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
+        {{ toctree(maxdepth=-1|toint, titles_only=True, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
       </li>
       {% else %}
       <li class="navleft-item"><a href="/docs/pdo/">PHP PDO</a></li>
@@ -127,7 +123,7 @@
       {% if project == 'CrateDB Python' %}
       <li class="current">
         <a class="current-active" href="{{ pathto(master_doc) }}">Python</a>
-        {{ toctree(maxdepth=3|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
+        {{ toctree(maxdepth=-1|toint, titles_only=True, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
       </li>
       {% else %}
       <li class="navleft-item"><a href="/docs/python/">Python</a></li>
@@ -135,7 +131,7 @@
       {% if project == 'SQLAlchemy Dialect' %}
       <li class="current">
         <a class="current-active" href="{{ pathto(master_doc) }}">SQLAlchemy</a>
-        {{ toctree(maxdepth=3|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
+        {{ toctree(maxdepth=-1|toint, titles_only=True, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
       </li>
       {% else %}
       <li class="navleft-item"><a href="/docs/sqlalchemy-cratedb/">SQLAlchemy</a></li>
@@ -143,7 +139,7 @@
       {% if project == 'CrateDB Npgsql' %}
       <li class="current">
         <a class="current-active" href="{{ pathto(master_doc) }}">.NET Npgsql</a>
-        {{ toctree(maxdepth=3|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
+        {{ toctree(maxdepth=-1|toint, titles_only=True, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
       </li>
       {% else %}
       <li class="navleft-item"><a href="/docs/npgsql/">.NET Npgsql</a></li>
@@ -167,14 +163,14 @@
   {% if project == 'CrateDB documentation theme' %}
     <li class="current border-top">
       <a class="current-active" href="{{ pathto(master_doc) }}">Documentation theme</a>
-      {{ toctree(maxdepth=3|toint, collapse=True, includehidden=theme_globaltoc_includehidden|tobool) }}
+      {{ toctree(maxdepth=-1|toint, titles_only=True, collapse=True, includehidden=theme_globaltoc_includehidden|tobool) }}
     </li>
   {% endif %}
 
   {% if project == 'Doing Docs' %}
   <li class="current">
     <a class="current-active" href="{{ pathto(master_doc) }}">Doing Docs at CrateDB</a>
-    {{ toctree(maxdepth=2|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
+    {{ toctree(maxdepth=-1|toint, titles_only=True, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
   </li>
   {% endif %}
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
See #607.

I've tested this by building each doc project with the new theme and checked that all TOC's now render as desired.

## Checklist

 - [x] Link to issue this PR refers to (if applicable): Fixes #607 
