### PR TITLE
pin sphinx-sitemap extension due to build warnings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ CHANGES
 
 Unreleased
 ----------
-
+- Pin ``sphinx-sitemap`` extension to <2.7.0 temporarily as that introduce build
+warnings (see https://github.com/crate/crate-docs/pull/115).
 - CrateDB Cloud: Removed special handling for the ``feature/index`` page as it
 no longer exists.
 - Updated left navbar TOC to only show titles of pages, but not "subsections" or

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
         "sphinx-copybutton>=0.3.1,<1",
         "sphinx-design-elements==0.4.0",
         "sphinx-inline-tabs",
-        "sphinx-sitemap>=2.6,<3",
+        "sphinx-sitemap<2.7.0", #temporarily pinned due to build warnings with 2.7.0
         "sphinx-subfigure<1",
         "sphinx-togglebutton<1",
         "sphinxext.opengraph>=0.4,<1",


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
See problem described [here](https://github.com/crate/crate-docs/pull/115)

