### PR TITLE
Phase out `crate-clients-tools`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ CHANGES
 
 Unreleased
 ----------
+- Phased out ``crate-clients-tools``
 
 2025/06/25 0.39.0
 -----------------

--- a/docs/projects.rst
+++ b/docs/projects.rst
@@ -28,7 +28,6 @@ CrateDB clients
 
 - :ref:`crate-admin-ui:index`
 - :ref:`crate-crash:index`
-- :ref:`crate-clients-tools:index`
 - :ref:`crate-jdbc:index`
 - :ref:`crate-npgsql:index`
 - :ref:`crate-dbal:index`

--- a/src/crate/theme/rtd/conf/__init__.py
+++ b/src/crate/theme/rtd/conf/__init__.py
@@ -108,7 +108,6 @@ intersphinx_mapping = {
 
     # CrateDB Clients and Integrations
     'crate-admin-ui': ('https://cratedb.com/docs/crate/admin-ui/en/latest/', None),
-    'crate-clients-tools': ('https://cratedb.com/docs/crate/clients-tools/en/latest/', None),
     'crate-crash': ('https://cratedb.com/docs/crate/crash/en/latest/', None),
     'crate-dbal': ('https://cratedb.com/docs/dbal/en/latest/', None),
     'crate-jdbc': ('https://cratedb.com/docs/jdbc/en/latest/', None),

--- a/src/crate/theme/rtd/crate/sidebartoc.html
+++ b/src/crate/theme/rtd/crate/sidebartoc.html
@@ -80,20 +80,16 @@
   <li class="navleft-item"><a href="/docs/cloud/cli/">Cloud CLI</a></li>
   {% endif %}
 
+  <li class="navleft-item">
+    <a href="/docs/guide/connect/drivers.html">Database Drivers</a>
+  </li>
   {%
   set driver_projects = [
-    'CrateDB: Clients and Tools',
     'CrateDB JDBC', 'CrateDB DBAL', 'CrateDB PDO', 'CrateDB Python', 'SQLAlchemy Dialect', 'CrateDB Npgsql'
   ]
   %}
-  {% if project in driver_projects %}
-  <li class="current">
-    {% if project == 'CrateDB: Clients and Tools' %}
-      <a class="current-active" href="{{ pathto(master_doc) }}">Drivers and Integrations</a>
-      {{ toctree(maxdepth=-1|toint, titles_only=True, collapse=True, includehidden=theme_globaltoc_includehidden|tobool) }}
-    {% else %}
-      <a class="current-active" href="/docs/crate/clients-tools/">Drivers and Integrations</a>
-    {% endif %}
+  {% if project in driver_projects or (project == 'CrateDB: Guide' and pagename.startswith('connect')) %}
+  <li>
     <ul>
       <!-- Section C. -->
       {% if project == 'CrateDB JDBC' %}
@@ -145,10 +141,6 @@
       <li class="navleft-item"><a href="/docs/npgsql/">.NET Npgsql</a></li>
       {% endif %}
     </ul>
-  </li>
-  {% else %}
-  <li class="navleft-item">
-    <a href="/docs/crate/clients-tools/">Drivers and Integrations</a>
   </li>
   {% endif %}
 


### PR DESCRIPTION
## About
Content from https://github.com/crate/crate-clients-tools has been migrated to https://github.com/crate/cratedb-guide.

## References
- https://github.com/crate/cratedb-guide/pull/221
- https://github.com/crate/cratedb-guide/pull/222