### PR TITLE
Start ignoring RTD API errors in compatibility layer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ Unreleased
 ----------
 - Phased out ``crate-clients-tools``
 - Changed link to "Sample Applications", now part of the new "Getting Started" section
+- Started ignoring RTD API errors in compatibility layer. It behaves flaky again,
+  possibly by becoming increasingly overloaded. The "ignore" fallback did not work
+  because, well, in this environment, warnings become errors.
 
 2025/06/25 0.39.0
 -----------------

--- a/src/crate/theme/vendor/rtd_compat/extension.py
+++ b/src/crate/theme/vendor/rtd_compat/extension.py
@@ -76,7 +76,7 @@ def manipulate_config(app, config):
                 for version in response_versions["results"]
             ]
         except Exception:
-            logger.warning(
+            logger.info(
                 "An error occurred when hitting API to fetch active versions. Defaulting to an empty list.",
                 exc_info=True,
             )


### PR DESCRIPTION
## About
The RTD API behaves flaky again, possibly by becoming increasingly overloaded. The "ignore" fallback added the other day did not work because, well, in this environment, warnings become errors.

## Details
```
WARNING: An error occurred when hitting API to fetch active versions. Defaulting to an empty list.
```
-- https://github.com/crate/cratedb-guide/actions/runs/17181695121/job/48744932084?pr=233#step:4:409
-- https://github.com/crate/crate-docs-theme/actions/runs/17176318205/job/48736558398?pr=621#step:7:441

## References
- GH-553