### PR TITLE
Rename "Guides and Tutorials" section name to just "Guides"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ CHANGES
 Unreleased
 ----------
 
+- Renamed "Guides and Tutorials" section name to just "Guides"
+
 2025/09/18 0.40.0
 -----------------
 - Phased out ``crate-clients-tools``

--- a/src/crate/theme/rtd/crate/sidebartoc.html
+++ b/src/crate/theme/rtd/crate/sidebartoc.html
@@ -35,11 +35,11 @@
 
   {% if project == 'CrateDB: Guide' and pagename != 'home/index' %}
     <li class="current">
-      <a class="current-active" href="{{ pathto(master_doc) }}">Guides and Tutorials</a>
+      <a class="current-active" href="{{ pathto(master_doc) }}">Guides</a>
       {{ toctree(maxdepth=-1|toint, titles_only=True, collapse=True, includehidden=theme_globaltoc_includehidden|tobool) }}
     </li>
   {% else %}
-    <li class="navleft-item"><a href="/docs/guide/">Guides and Tutorials</a></li>
+    <li class="navleft-item"><a href="/docs/guide/">Guides</a></li>
   {% endif %}
 
   {% if project == 'CrateDB: Reference' %}


### PR DESCRIPTION
## About

A small naming change as proposed.
