### PR TITLE
Naming things: Per Diátaxis, using "Guides" is not applicable. Use "Handbook" instead.

### DIFF
--- a/src/crate/theme/rtd/crate/sidebartoc.html
+++ b/src/crate/theme/rtd/crate/sidebartoc.html
@@ -35,11 +35,11 @@
 
   {% if project == 'CrateDB: Guide' and pagename != 'home/index' %}
     <li class="current">
-      <a class="current-active" href="{{ pathto(master_doc) }}">Guides</a>
+      <a class="current-active" href="{{ pathto(master_doc) }}">Handbook</a>
       {{ toctree(maxdepth=-1|toint, titles_only=True, collapse=True, includehidden=theme_globaltoc_includehidden|tobool) }}
     </li>
   {% else %}
-    <li class="navleft-item"><a href="/docs/guide/">Guides</a></li>
+    <li class="navleft-item"><a href="/docs/guide/">Handbook</a></li>
   {% endif %}
 
   {% if project == 'CrateDB: Reference' %}


### PR DESCRIPTION
## About

I think we agree that "Guides" is wrong according to [Diátaxis](https://github.com/crate/cratedb-guide/issues/335). Why not just use "Handbook", as it's a neutral term, not tainted too much, and easily understandable. In the absence of a better proposal, we may just go ahead and give it a try for a while. Renaming the repository and the URL entrypoint can optionally follow on a subsequent iteration.
