### PR TITLE
Version chooser: Stop navigation path from `master` to `latest` in certain conditions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ CHANGES
 
 Unreleased
 ----------
+- Stopped version chooser navigation path from ``master`` to ``latest`` in
+  the ``appendices/release-notes`` section of the reference documentation.
 
 2025/10/08 0.41.0
 -----------------

--- a/src/crate/theme/rtd/crate/components/version_chooser.html
+++ b/src/crate/theme/rtd/crate/components/version_chooser.html
@@ -65,9 +65,11 @@
     </summary>
     <div class="sd-summary-content sd-card-body docutils version-chooser__menu">
       {% for slug, url in versions %}
+      {% if not ("master" in github_version and slug == "latest" and pagename.startswith("appendices/release-notes")) %}
       <script>
         versionChooserAppendItem('{{ slug }}', '{{ url }}');
       </script>
+      {% endif %}
       {% endfor %}
     </div>
   </details>


### PR DESCRIPTION
## About
We discovered an unfortunate navigation path where the version chooser widget renders broken links, which specifically becomes apparent in the `appendices/release-notes` section of the reference documentation.

## Thoughts
This is not much of a concern anywhere else where we use versioned documentation [^1], because documentation layout is pretty stable on those artefacts, so relevant deviances mostly just don't happen.

In this spirit, we think it's applicable to mitigate rendering broken links by applying this specific workaround, even if it introduces a little heuristic based on concrete subject matters.

## References
- https://github.com/crate/crate-docs-theme/issues/639

[^1]: Because there wasn't much need, we disabled the version chooser on many other projects anyway today, so all of this applies mostly to the CrateDB reference documentation anyway.