### PR TITLE
Primary navigation: Stop expanding "integrations" section

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ CHANGES
 
 Unreleased
 ----------
+- Primary navigation: Stopped expanding "integrations" section
 
 2025/10/08 0.41.0
 -----------------

--- a/src/crate/theme/rtd/crate/sidebartoc.html
+++ b/src/crate/theme/rtd/crate/sidebartoc.html
@@ -28,7 +28,11 @@
     {% endif %}
     <!-- Show all remaining TOC entries in the root -->
     <li class="current toctree-l0">
-      {{ toctree(maxdepth=-1|toint, titles_only=True, collapse=True, includehidden=theme_globaltoc_includehidden|tobool) }}
+      {% if pagename.startswith('integrate') %}
+      {{ toctree(maxdepth=2|toint, titles_only=True, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
+      {% else %}
+      {{ toctree(maxdepth=-1|toint, titles_only=True, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}
+      {% endif %}
     </li>
   {% else %}
     <!-- Show Guide sections as links in other projects -->


### PR DESCRIPTION
## About

A study how it would work when omitting parts of the primary navigation, because some find it distracting. In this case, stop expanding the "integrations" section, because it includes a pretty long list of items.

## Evaluation

We might retract this patch later if it causes more troubles than benefits.
