### PR TITLE
Remove sphinx-subfigure extension

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ CHANGES
 Unreleased
 ----------
 
+- Removed the ``sphinx-subfigure`` extension.
+
 2025/10/08 0.41.0
 -----------------
 - Added support for including the entire level0 entries in the sidebar TOC for a

--- a/docs/myst/image-figure.md
+++ b/docs/myst/image-figure.md
@@ -44,32 +44,3 @@ table:
 | ------ | ------- |
 | :logo: | MyST    |
 ```
-
-
-## Subfigures
-
-Documentation: https://sphinx-subfigure.readthedocs.io/
-
-:::{subfigure} AA|BC
-:layout-sm: A|B|C
-:gap: 8px
-:subcaptions: above
-:name: myfigure
-:class-grid: outline
-
-```{image} https://sphinx-subfigure.readthedocs.io/en/latest/_images/A.png
-:height: 100px
-:alt: Image A
-```
-
-```{image} https://sphinx-subfigure.readthedocs.io/en/latest/_images/B.png
-:height: 100px
-:alt: Image B
-```
-
-```{image} https://sphinx-subfigure.readthedocs.io/en/latest/_images/C.png
-:height: 100px
-:alt: Image C
-```
-
-:::

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,6 @@ setup(
         "sphinx-design-elements==0.4.0",
         "sphinx-inline-tabs",
         "sphinx-sitemap<2.9.0",
-        "sphinx-subfigure<1",
         "sphinx-togglebutton<1",
         "sphinxext.opengraph>=0.4,<1",
         "sphinxcontrib-mermaid<2",

--- a/src/crate/theme/rtd/conf/__init__.py
+++ b/src/crate/theme/rtd/conf/__init__.py
@@ -40,7 +40,6 @@ extensions = [
     "sphinx_design_elements",
     "sphinx_inline_tabs",
     "sphinx_sitemap",
-    "sphinx_subfigure",
     "sphinx_togglebutton",
     "sphinx.ext.intersphinx",
     "sphinx.ext.todo",


### PR DESCRIPTION
Trying to run sphinx-build with -j auto fails:

> Warning, treated as error: the sphinx_subfigure extension does not
> declare if it is safe for parallel reading, assuming it isn't - please
> ask the extension author to check and make it explicit

The extension isn't used anywhere within the crate organization -> 🚮
