### PR TITLE
Security: Use `enableScripts: false` to suppress `postinstall` tasks

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+enableScripts: false


### PR DESCRIPTION
## About

> Disable `npm` postinstall scripts [in CI] where possible.

## References

- https://github.com/crate/crate-clients-tools/issues/274

/cc @wmKvXo, @surister, @kneth