### PR TITLE
Remove bottom 3 links in TOC

### DIFF
--- a/src/crate/theme/rtd/crate/sidebartoc.html
+++ b/src/crate/theme/rtd/crate/sidebartoc.html
@@ -150,9 +150,6 @@
   <!-- Section D. -->
   <li class="navleft-item border-top"><a target="_blank" href="/support/">Support</a></li>
   <li class="navleft-item"><a target="_blank" href="https://community.cratedb.com/">Community</a></li>
-  <li class="navleft-item"><a target="_blank" href="https://community.cratedb.com/t/overview-of-cratedb-integration-tutorials/1015">Integration Tutorials</a></li>
-  <li class="navleft-item"><a href="/docs/guide/start/application/index.html">Sample Applications</a></li>
-  <li class="navleft-item"><a target="_blank" href="https://learn.cratedb.com">Academy</a></li>
 
   <!-- Section E. -->
   {% if project == 'CrateDB documentation theme' %}


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
This removes the bottom 3 links in the left TOC:
- Integration Tutorials: It's a link to the community articles. Many have been moved to docs. If more are needed we should have this in the Integrations section. @motl: Let me know If I you think a general link in the Integrations page would be helpful?
- Sample Applications: It's now in Getting Started
- Academi: It's now in Getting Started

## Preview
https://crate-docs-theme--660.org.readthedocs.build/en/660/

TOC will now look like this:
<img width="294" height="413" alt="image" src="https://github.com/user-attachments/assets/50a44df2-0cba-4645-b3be-218b647809d7" />
 