### PR TITLE
Dependencies: Update to `sphinx-design-elements` v0.4.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ CHANGES
 
 Unreleased
 ----------
+- Updated to ``sphinx-design-elements`` v0.4.1
 
 2025/11/05 0.42.0
 -----------------

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
         "sphinx>=7.1,<9",
         "sphinx-basic-ng==1.0.0b2",
         "sphinx-copybutton>=0.3.1,<1",
-        "sphinx-design-elements==0.4.0",
+        "sphinx-design-elements==0.4.1",
         "sphinx-inline-tabs",
         "sphinx-sitemap<2.10.0",
         "sphinx-togglebutton<1",


### PR DESCRIPTION
## About
Just maintenance.

## References
- https://github.com/tech-writing/sphinx-design-elements/releases/tag/v0.4.1