### PR TITLE
Provide CrateDB reference documentation per `cratedb` intersphinx domain

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ CHANGES
 
 Unreleased
 ----------
+- Breaking change: Started providing CrateDB reference documentation per
+  ``cratedb`` intersphinx domain. The label is much shorter than
+  ``crate-reference``, so it saves keystrokes and uses less screen space.
 
 2025/12/17 0.44.0
 -----------------

--- a/docs/projects.rst
+++ b/docs/projects.rst
@@ -20,7 +20,7 @@ CrateDB core
 ------------
 
 - :ref:`guide:index`
-- :ref:`crate-reference:index`
+- :ref:`cratedb:index`
 
 
 CrateDB clients

--- a/src/crate/theme/rtd/conf/__init__.py
+++ b/src/crate/theme/rtd/conf/__init__.py
@@ -102,7 +102,7 @@ intersphinx_mapping = {
 
     # CrateDB General
     'guide': ('https://cratedb.com/docs/guide/', None),
-    'crate-reference': ('https://cratedb.com/docs/crate/reference/en/latest/', None),
+    'cratedb': ('https://cratedb.com/docs/crate/reference/en/latest/', None),
 
     # CrateDB Clients and Integrations
     'crate-admin-ui': ('https://cratedb.com/docs/crate/admin-ui/en/latest/', None),


### PR DESCRIPTION
## About
`cratedb` is much shorter than `crate-reference`, so this label saves keystrokes and uses less screen space.

## Backlog
It is a breaking change, so it must be accompanied by corresponding updates on downstream projects. This applies to just 100 spots in seven repositories, so that's certainly doable using a sweeping search/replace operation.

- https://github.com/search?q=org%3Acrate+crate-reference%3A&type=code

## References
- https://github.com/crate/cratedb-guide/pull/503