### PR TITLE
Remove deprecated License classifier from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setup(
     long_description_content_type="text/x-rst",
     classifiers=[
         "Intended Audience :: Developers",
-        "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Removes build warning about deprecated license classifier. Having `license="Apache License 2.0"` as we already have is sufficient. 
See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license

## Checklist
 - [x] Link to issue this PR refers to (if applicable): Fixes #679 
