### PR TITLE
Remove outmoded database drivers section

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ CHANGES
 Unreleased
 ----------
 - Bugfix for TOC expand/collapse not working well across projects.
+- Removed outmoded database drivers section
 
 2026/01/08 0.46.0
 -----------------

--- a/src/crate/theme/rtd/sidebartoc.py
+++ b/src/crate/theme/rtd/sidebartoc.py
@@ -150,38 +150,9 @@ def _generate_crate_navigation_html(context):
     builder.add_project_nav_item('CrateDB: Crash CLI', 'CrateDB CLI', '/docs/crate/crash/')
     builder.add_project_nav_item('CrateDB Cloud: Croud CLI', 'Cloud CLI', '/docs/cloud/cli/')
 
-    # Add all Driver projects
-    # The <ul> must be inside the same <li> for CSS sibling selectors to work
-    _DRIVER_CONFIGS = [
-        ('CrateDB JDBC', 'JDBC', '/docs/jdbc/'),
-        ('CrateDB DBAL', 'PHP DBAL', '/docs/dbal/'),
-        ('CrateDB PDO', 'PHP PDO', '/docs/pdo/'),
-        ('CrateDB Python', 'Python', '/docs/python/'),
-        ('SQLAlchemy Dialect', 'SQLAlchemy', '/docs/sqlalchemy-cratedb/'),
-    ]
-    driver_projects = [config[0] for config in _DRIVER_CONFIGS]
-    show_drivers = project in driver_projects or (project == 'CrateDB: Guide' and pagename.startswith('connect'))
-
-    # Use data attribute to mark Database Drivers for auto-expansion
-    driver_marker = ' data-auto-expand="true"' if show_drivers else ''
-    # Add current class when viewing a driver page to make it bold
-    driver_class = 'current' if show_drivers else 'navleft-item'
-    driver_link_class = ' class="current-active"' if show_drivers else ''
-    parts.append(f'<li class="{driver_class}"{driver_marker}>')
-    parts.append(f'<a{driver_link_class} href="/docs/guide/connect/drivers.html">Database Drivers</a>')
-    # Furo will add has-children class and icon structure when it detects the <ul>
-    parts.append('<ul>')
-    if show_drivers:
-        for proj_name, display_name, url in _DRIVER_CONFIGS:
-            builder.add_project_nav_item(proj_name, display_name, url)
-    parts.append('</ul>')
-    parts.append('</li>')
-
-
     # Add Support and Community links section after a border
     parts.append('<li class="navleft-item border-top"><a target="_blank" href="/support/">Support</a></li>')
     parts.append('<li class="navleft-item"><a target="_blank" href="https://community.cratedb.com/">Community</a></li>')
-
 
     # Other internal docs projects only included in special builds
     builder.add_project_nav_item('CrateDB documentation theme', 'Documentation theme', '', border_top=True, public_docs=False)


### PR DESCRIPTION
## About

The drivers section was [modernized and relocated](https://cratedb.com/docs/guide/connect/). This patch removes the redundant outmoded one, where most items can easily be considered legacy and stale today.

After CrateDB received PostgreSQL compatibility, it gained a way larger surface of connectivity options, which is a good thing. At the same time, our legacy drivers became less maintained, which is natural. In this spirit, we shouldn't present them any longer on the main stage, but just refer to them within a larger gallery where other more optimal connectivity options exist, mostly through drivers and adapters which are NOT from our pen. [^1]

## References

- https://github.com/crate/tech-content/issues/124#issuecomment-3738490742

[^1]: On the other hand, this absolutely doesn't mean they don't need maintenance dearly. The PHP drivers received a few cycles recently, but we don't even mention the legacy Ruby drivers there. Today, mostly the JDBC driver is in a sad state since ages. **Please improve, so we can finally add and present Hibernate support, possibly on the main stage!**

/cc @seut, @matriv, @surister 