### PR TITLE
Add external link icon to the two links in the left-hand TOC

### DIFF
--- a/src/crate/theme/rtd/crate/static/css/crateio-rtd.css
+++ b/src/crate/theme/rtd/crate/static/css/crateio-rtd.css
@@ -194,3 +194,17 @@ a code {
 div.topic {
   border: 0;
 }
+
+/* External link icon for sidebar TOC links */
+.toctree a.external-link::after {
+  content: "";
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  margin-left: 6px;
+  background: url(../images/icon_link_external.svg) no-repeat center;
+  background-size: contain;
+  vertical-align: middle;
+  filter: grayscale(100%);
+  opacity: 0.6;
+}

--- a/src/crate/theme/rtd/sidebartoc.py
+++ b/src/crate/theme/rtd/sidebartoc.py
@@ -179,8 +179,8 @@ def _generate_crate_navigation_html(context):
 
 
     # Add Support and Community links section after a border
-    parts.append('<li class="navleft-item border-top"><a target="_blank" href="/support/">Support</a></li>')
-    parts.append('<li class="navleft-item"><a target="_blank" href="https://community.cratedb.com/">Community</a></li>')
+    parts.append('<li class="navleft-item border-top"><a class="external-link" target="_blank" href="/support/">Support</a></li>')
+    parts.append('<li class="navleft-item"><a class="external-link" target="_blank" href="https://community.cratedb.com/">Community</a></li>')
 
 
     # Other internal docs projects only included in special builds


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Indicate that clicking the links (Support or Community) will open another page external to the docs.

## Preview
<img width="245" height="85" alt="image" src="https://github.com/user-attachments/assets/92392702-99ca-4e5a-82cb-f08b70d86856" />

https://crate-docs-theme--688.org.readthedocs.build/en/688/

