### PR TITLE
Improved stepper with {rubric} support

### DIFF
--- a/docs/myst/stepper.md
+++ b/docs/myst/stepper.md
@@ -32,6 +32,11 @@ Steps can contain lists and admonitions:
 Example admonition.
 :::
 
+You can also use ":::{rubric}":
+
+:::{rubric} Rubric text
+:::
+
 ### Step three (a h3 header)
 
 Steps can contain nested headings. You just have to make them one level smaller.


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Previously `{rubric}` directives would be rendered as a "Step" if inside a `{stepper}` directive. That's been fixed so they now behave normally.

## Preview
Visible here: https://crate-docs-theme--694.org.readthedocs.build/en/694/myst/stepper.html