### PR TITLE
Chore: Satisfy link checker

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,5 +37,6 @@ intersphinx_mapping["sde"] = ("https://sphinx-design-elements.readthedocs.io/en/
 
 
 linkcheck_ignore += [
+    "https://docutils.sourceforge.io/",
     "https://github.com/",
 ]


### PR DESCRIPTION
## Problem
https://docutils.sourceforge.io/ returns `403 Client Error: Forbidden`.
