### PR TITLE
Configure HTTP user agent per `linkcheck_request_headers` setting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ CHANGES
 
 Unreleased
 ----------
-
+- Configured HTTP user agent per ``linkcheck_request_headers`` setting
 
 2026/01/27 0.48.0
 -----------------

--- a/src/crate/theme/rtd/conf/__init__.py
+++ b/src/crate/theme/rtd/conf/__init__.py
@@ -182,6 +182,9 @@ linkcheck_anchors_ignore_for_url = [
 ]
 linkcheck_retries = 3
 linkcheck_timeout = 15
+linkcheck_request_headers = {
+    "User-Agent": "CrateDB docs linkcheck"
+}
 
 # -- Options for MyST -------------------------------------------------
 myst_heading_anchors = 3


### PR DESCRIPTION
## About
> Daily linkcheck job has been failing with 403's.
>
> Maybe setting a User-Agent helps avoid getting blocked by
> AI-bot/crawler protection mechanisms.

## References
- https://github.com/crate/crate/pull/19006