### PR TITLE
Navigation: Add references to CrateDB MCP and CrateDB Toolkit

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ CHANGES
 
 Unreleased
 ----------
+- Navigation: Added references to CrateDB MCP and CrateDB Toolkit
 
 2026/02/12 0.49.1
 -----------------

--- a/src/crate/theme/rtd/sidebartoc.py
+++ b/src/crate/theme/rtd/sidebartoc.py
@@ -184,6 +184,8 @@ def _generate_crate_navigation_html(context):
     builder.add_project_nav_item('CrateDB: Admin UI', 'Admin UI', '/docs/crate/admin-ui/')
     builder.add_project_nav_item('CrateDB: Crash CLI', 'CrateDB CLI', '/docs/crate/crash/')
     builder.add_project_nav_item('CrateDB Cloud: Croud CLI', 'Cloud CLI', '/docs/cloud/cli/')
+    parts.append('<li class="navleft-item"><a class="external-link" target="_blank" href="https://cratedb-mcp.readthedocs.io/">CrateDB MCP</a></li>')
+    parts.append('<li class="navleft-item"><a class="external-link" target="_blank" href="https://cratedb-toolkit.readthedocs.io/">CrateDB Toolkit</a></li>')
 
     # Add Support and Community links section after a border
     parts.append('<li class="navleft-item border-top"><a class="external-link" target="_blank" href="/support/">Support</a></li>')


### PR DESCRIPTION
## About
After the primary navigation received a significant facelift and other trimming (thanks a stack, @bmunkholm!), let's populate it again with reasonable cross links.

## Review
CI failures are unrelated to this patch, so they can be ignored. See GH-706.

/cc @karynzv, @hammerhead, @kneth 