### PR TITLE
Link checker: Start ignoring `example.org` due to certificate errors

### DIFF
--- a/src/crate/theme/rtd/conf/__init__.py
+++ b/src/crate/theme/rtd/conf/__init__.py
@@ -175,6 +175,10 @@ linkcheck_ignore = [
     "https://www.gnu.org/.*",
     # Temporary failure in name resolution
     "https://jupysql.ploomber.io/.*",
+    # Sporadic CERTIFICATE_VERIFY_FAILED errors.
+    # https://github.com/crate/crate-docs-theme/issues/706
+    r"https://example.com.*",
+    r"https://www.example.com.*",
 ]
 linkcheck_anchors_ignore_for_url = [
     # Requires JavaScript.


### PR DESCRIPTION
## Problem
```
HTTPSConnectionPool(host='www.example.org', port=443): Max retries exceeded
[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed:
unable to get local issuer certificate (_ssl.c:1081)
```

## References
- https://github.com/crate/crate-docs-theme/issues/706
