### PR TITLE
Fix: Overview always bolded when selected

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,12 @@ CHANGES
 Unreleased
 ----------
 
+
+2026/02/22 0.50.2
+-----------------
+- Fix: "Overview" TOC entry wasn't bolded when it's subpage had been visited and
+Overview was selected again.
+
 2026/02/22 0.50.1
 -----------------
 - Fix: CSS now loads independently of JavaScript, reducing load time and

--- a/src/crate/theme/rtd/__init__.py
+++ b/src/crate/theme/rtd/__init__.py
@@ -23,7 +23,7 @@
 
 import os
 
-VERSION = (0, 50, 1)
+VERSION = (0, 50, 2)
 
 __version__ = ".".join(str(v) for v in VERSION) # + ".dev0"
 __version_full__ = __version__

--- a/src/crate/theme/rtd/crate/static/js/swup.js
+++ b/src/crate/theme/rtd/crate/static/js/swup.js
@@ -136,13 +136,18 @@ function syncClassesByIndex(liveSidebar, liveAnchors, fetchedAnchors) {
             liveAnchor.setAttribute('href', resolveLocalHref(fetchedHref, baseUrl));
         }
 
-        liveAnchor.classList.toggle('current', fetchedAnchor.classList.contains('current'));
+        // '#' href means this is the current page's own toctree entry (Sphinx
+        // self-reference, or our Overview link rewritten to master_path="#" on
+        // the root page by sidebartoc.py). Sphinx doesn't add 'current' to the
+        // Overview entry in that case, so we infer it from the href instead.
+        const isSelfRef = fetchedHref === '#';
+        liveAnchor.classList.toggle('current', fetchedAnchor.classList.contains('current') || isSelfRef);
 
         const liveItem = liveAnchor.closest('li');
         const fetchedItem = fetchedAnchor.closest('li');
         if (liveItem && fetchedItem) {
-            liveItem.classList.toggle('current', fetchedItem.classList.contains('current'));
-            liveItem.classList.toggle('current-page', fetchedItem.classList.contains('current-page'));
+            liveItem.classList.toggle('current', fetchedItem.classList.contains('current') || isSelfRef);
+            liveItem.classList.toggle('current-page', fetchedItem.classList.contains('current-page') || isSelfRef);
         }
     });
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Fixed "Overview" TOC entry wasn't bolded when it's subpage had been visited and Overview was selected again.
