### PR TITLE
Add agent skills to the menu

### DIFF
--- a/src/crate/theme/rtd/sidebartoc.py
+++ b/src/crate/theme/rtd/sidebartoc.py
@@ -183,6 +183,7 @@ def _generate_crate_navigation_html(context):
     builder.add_project_nav_item('CrateDB: Crash CLI', 'CrateDB CLI', '/docs/crate/crash/')
     builder.add_project_nav_item('CrateDB Cloud: Croud CLI', 'Cloud CLI', '/docs/cloud/cli/')
     parts.append('<li class="navleft-item"><a class="external-link" target="_blank" href="https://cratedb-mcp.readthedocs.io/">CrateDB MCP</a></li>')
+    parts.append('<li class="navleft-item"><a class="external-link" target="_blank" href="https://github.com/crate/agent-skills/">CrateDB Agent Skills</a></li>')
     parts.append('<li class="navleft-item"><a class="external-link" target="_blank" href="https://cratedb-toolkit.readthedocs.io/">CrateDB Toolkit</a></li>')
 
     # Add Support and Community links section after a border


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Adding a link to the agent skills. For now, the link it directly to the GitHub repository, and `README.md` has a brief section on how to install the skills in Claude Code

## Checklist

 - [ ] ~Link to issue this PR refers to (if applicable): Fixes #???~
